### PR TITLE
fix: resolve click timeout on combobox elements

### DIFF
--- a/src/commands/click.ts
+++ b/src/commands/click.ts
@@ -33,7 +33,13 @@ export async function handleClick(
 						exact: true,
 					});
 
-		await locator.click({ timeout: 10_000 });
+		// Combobox elements (reka-ui/Radix/shadcn) fail Playwright's actionability
+		// checks despite being visible and interactive. Force bypasses those checks.
+		const clickOpts: { timeout: number; force?: boolean } = { timeout: 10_000 };
+		if (resolved.role === "combobox") {
+			clickOpts.force = true;
+		}
+		await locator.click(clickOpts);
 
 		return {
 			ok: true,

--- a/test/interactions.test.ts
+++ b/test/interactions.test.ts
@@ -110,6 +110,52 @@ describe("handleClick", () => {
 			expect(result.error).toContain("stale");
 		}
 	});
+
+	test("clicks combobox elements with force to bypass actionability checks", async () => {
+		clearRefs();
+		assignRefs(
+			makeTree({ role: "combobox", name: "Select option...", children: [] }),
+			"default",
+		);
+
+		const clickMock = mock(() => Promise.resolve());
+		const page = {
+			getByRole: mock((_role: string, _opts?: Record<string, unknown>) => ({
+				nth: mock((_n: number) => ({
+					click: clickMock,
+				})),
+				click: clickMock,
+			})),
+		} as never;
+
+		const result = await handleClick(page, ["@e1"]);
+
+		expect(result.ok).toBe(true);
+		expect(clickMock).toHaveBeenCalledWith({ timeout: 10_000, force: true });
+	});
+
+	test("clicks non-combobox elements without force", async () => {
+		clearRefs();
+		assignRefs(
+			makeTree({ role: "button", name: "Submit", children: [] }),
+			"default",
+		);
+
+		const clickMock = mock(() => Promise.resolve());
+		const page = {
+			getByRole: mock((_role: string, _opts?: Record<string, unknown>) => ({
+				nth: mock((_n: number) => ({
+					click: clickMock,
+				})),
+				click: clickMock,
+			})),
+		} as never;
+
+		const result = await handleClick(page, ["@e1"]);
+
+		expect(result.ok).toBe(true);
+		expect(clickMock).toHaveBeenCalledWith({ timeout: 10_000 });
+	});
 });
 
 describe("handleFill", () => {


### PR DESCRIPTION
Closes #33

## Summary

- Combobox elements (`[role="combobox"]`) from reka-ui, Radix, and shadcn consistently timeout (10s) when clicked via `browse click @ref` because Playwright's actionability checks block despite the element being visible and interactive
- Fix: pass `force: true` to Playwright's `.click()` for combobox role elements, bypassing actionability checks while preserving the full click event sequence (pointerdown → mousedown → pointerup → mouseup → click)
- Non-combobox elements are unaffected — they continue using standard actionability checks

## Test plan

- [x] Unit tests: added tests verifying `force: true` is passed for combobox clicks and not for other roles
- [x] Full test suite passes (709 tests)
- [x] Manual verification: tested against reka-ui Select component (`<button role="combobox">`) at https://reka-ui.com/docs/components/select — click succeeds instantly and dropdown opens (`aria-expanded=true`)