### PR TITLE
fix: support custom ARIA comboboxes in select command

### DIFF
--- a/src/commands/select.ts
+++ b/src/commands/select.ts
@@ -50,7 +50,23 @@ export async function handleSelect(
 						exact: true,
 					});
 
-		await locator.selectOption({ label: optionText }, { timeout: 10_000 });
+		try {
+			await locator.selectOption({ label: optionText }, { timeout: 10_000 });
+		} catch (nativeErr) {
+			const msg =
+				nativeErr instanceof Error ? nativeErr.message : String(nativeErr);
+			if (!msg.includes("not a <select> element")) {
+				throw nativeErr;
+			}
+			// Custom ARIA combobox — focus, press ArrowDown to open, then click the option
+			await locator.focus({ timeout: 10_000 });
+			await page.keyboard.press("ArrowDown");
+			const option = page.getByRole("option", {
+				name: optionText,
+				exact: true,
+			});
+			await option.click({ timeout: 10_000 });
+		}
 
 		return {
 			ok: true,

--- a/test/interactions.test.ts
+++ b/test/interactions.test.ts
@@ -326,6 +326,80 @@ describe("handleSelect", () => {
 
 		expect(result.ok).toBe(true);
 	});
+
+	test("falls back to keyboard-based selection for custom ARIA comboboxes", async () => {
+		clearRefs();
+		assignRefs(
+			makeTree({ role: "combobox", name: "Placeholder...", children: [] }),
+			"default",
+		);
+
+		const optionClickMock = mock(() => Promise.resolve());
+		const focusMock = mock(() => Promise.resolve());
+		const pressMock = mock(() => Promise.resolve());
+		const page = {
+			keyboard: { press: pressMock },
+			getByRole: mock((role: string, _opts?: Record<string, unknown>) => {
+				if (role === "option") {
+					return {
+						click: optionClickMock,
+					};
+				}
+				return {
+					nth: mock(() => ({
+						selectOption: mock(() => {
+							throw new Error("Element is not a <select> element");
+						}),
+						focus: focusMock,
+					})),
+					selectOption: mock(() => {
+						throw new Error("Element is not a <select> element");
+					}),
+					focus: focusMock,
+				};
+			}),
+		} as never;
+
+		const result = await handleSelect(page, ["@e1", "Aatrox"]);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toContain("Selected");
+			expect(result.data).toContain("Aatrox");
+		}
+		// Should have focused the trigger, pressed ArrowDown, then clicked the option
+		expect(focusMock).toHaveBeenCalledWith({ timeout: 10_000 });
+		expect(pressMock).toHaveBeenCalledWith("ArrowDown");
+		expect(optionClickMock).toHaveBeenCalledWith({ timeout: 10_000 });
+	});
+
+	test("propagates non-select errors without fallback", async () => {
+		clearRefs();
+		assignRefs(
+			makeTree({ role: "combobox", name: "Role", children: [] }),
+			"default",
+		);
+
+		const page = {
+			getByRole: mock(() => ({
+				nth: mock(() => ({
+					selectOption: mock(() => {
+						throw new Error("Timeout 10000ms exceeded.");
+					}),
+				})),
+				selectOption: mock(() => {
+					throw new Error("Timeout 10000ms exceeded.");
+				}),
+			})),
+		} as never;
+
+		const result = await handleSelect(page, ["@e1", "Admin"]);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("Timeout");
+		}
+	});
 });
 
 describe("handlePress", () => {


### PR DESCRIPTION
Closes #34

## Summary

- When `browse select` targets a custom ARIA combobox (not a native `<select>`), falls back to the standard ARIA keyboard interaction: focus → ArrowDown → click matching option
- Native `<select>` elements continue to use Playwright's `selectOption()` as before
- Non-select errors (e.g. timeouts) are propagated without triggering the fallback

## Test plan

- [x] Unit tests: custom combobox fallback path, error propagation
- [x] All 711 tests pass
- [x] Verified live against https://reka-ui.com/docs/components/combobox — `browse select @e78 "Pear"` successfully selects the option