### PR TITLE
fix: quote SKILL.md description for valid YAML frontmatter

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browse
-description: Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include "browse", "check the page", "take a screenshot", "test the UI", "fill the form", "click the button", "QA", "visual check", "healthcheck", and any task requiring a real browser.
+description: "Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include: any mention of 'browse', 'check the page', 'take a screenshot', 'test the UI', 'fill the form', 'click the button', 'QA', 'visual check', 'healthcheck', and any task requiring a real browser."
 allowed-tools: Bash(browse:*)
 ---
 


### PR DESCRIPTION
## Summary
- Wraps the `description` field in SKILL.md in double quotes and converts inner double quotes to single quotes
- The previous frontmatter contained unquoted embedded double quotes, which is invalid YAML

## Test plan
- [x] `bun run check:fix` passes
- [ ] Verify skill still appears in Claude Code's available skills list