### PR TITLE
fix: ad-hoc codesign macOS binaries after Bun compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
             ./src/cli.ts --outfile dist/${{ matrix.artifact }} \
             --external electron --external chromium-bidi
 
+      - name: Ad-hoc sign macOS binary
+        if: runner.os == 'macOS'
+        run: codesign -s - -f dist/${{ matrix.artifact }}
+
       - name: Upload binary to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,13 @@ if ! curl -fSL --progress-bar -o "${BIN_DIR}/browse" "$DOWNLOAD_URL"; then
 fi
 
 chmod +x "${BIN_DIR}/browse"
+
+# Re-sign on macOS — downloaded binaries may have invalid signatures
+if [ "$(uname -s)" = "Darwin" ]; then
+  codesign -s - -f "${BIN_DIR}/browse" 2>/dev/null || true
+  xattr -d com.apple.quarantine "${BIN_DIR}/browse" 2>/dev/null || true
+fi
+
 echo "  binary: ${BIN_DIR}/browse"
 
 # Install Playwright Chromium

--- a/setup.sh
+++ b/setup.sh
@@ -56,6 +56,12 @@ if [ ! -f dist/browse ]; then
   exit 1
 fi
 
+# Re-sign on macOS — Bun's --compile invalidates the linker signature
+if [ "$(uname -s)" = "Darwin" ]; then
+  codesign -s - -f dist/browse
+  echo "  ✓ ad-hoc signed"
+fi
+
 # Copy screenxy-fix extension alongside the binary
 if [ -d extensions/screenxy-fix ]; then
   mkdir -p dist/extensions/screenxy-fix


### PR DESCRIPTION
## Summary

- Bun's `--compile` appends bundled JS to the Mach-O binary after the linker signs it, invalidating the ad-hoc code signature. macOS kills the binary on launch with SIGKILL.
- Added `codesign -s - -f` after compilation in `setup.sh`, `release.yml`, and `install.sh` to re-sign the binary.
- Also strips `com.apple.quarantine` xattr in `install.sh` as a safety net for downloaded binaries.

## Test plan

- [x] Verified locally: re-signed binary passes `codesign -v` and `browse goto` works
- [ ] Trigger a release and confirm the macOS binary from GitHub Releases works without being killed