### PR TITLE
fix: global flags work in any position (#46)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,33 +59,35 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
 	if (filteredArgv2[0] === "--daemon") return { daemon: true, config, listen };
 
-	const [cmd, ...rawArgs] = filteredArgv2;
-
-	// Extract global flags
+	// Extract global flags (--timeout, --session, --json) from anywhere in argv
 	let timeout: number | undefined;
 	let session: string | undefined;
 	let json = false;
-	const args: string[] = [];
+	const remaining: string[] = [];
 
-	for (let i = 0; i < rawArgs.length; i++) {
-		if (rawArgs[i] === "--timeout" && i + 1 < rawArgs.length) {
-			const val = Number.parseInt(rawArgs[i + 1], 10);
+	for (let i = 0; i < filteredArgv2.length; i++) {
+		if (filteredArgv2[i] === "--timeout" && i + 1 < filteredArgv2.length) {
+			const val = Number.parseInt(filteredArgv2[i + 1], 10);
 			if (!Number.isNaN(val) && val > 0) {
 				timeout = val;
 			}
 			i++; // skip the value
-		} else if (rawArgs[i] === "--session") {
-			if (i + 1 < rawArgs.length) {
-				session = rawArgs[i + 1];
+		} else if (filteredArgv2[i] === "--session") {
+			if (i + 1 < filteredArgv2.length) {
+				session = filteredArgv2[i + 1];
 				i++; // skip the value
 			}
 			// Missing value: --session flag is silently ignored (same as --timeout)
-		} else if (rawArgs[i] === "--json") {
+		} else if (filteredArgv2[i] === "--json") {
 			json = true;
 		} else {
-			args.push(rawArgs[i]);
+			remaining.push(filteredArgv2[i]);
 		}
 	}
+
+	if (remaining.length === 0) return null;
+
+	const [cmd, ...args] = remaining;
 
 	return { cmd: cmd as string, args, timeout, session, json, config };
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -294,6 +294,95 @@ describe("parseArgs", () => {
 			json: false,
 		});
 	});
+
+	// Issue #46: Global flags placed before the command name
+	test("--timeout before command is parsed correctly", () => {
+		const result = parseArgs(["--timeout", "5000", "ping"]);
+		expect(result).toEqual({
+			cmd: "ping",
+			args: [],
+			timeout: 5000,
+			session: undefined,
+			json: false,
+		});
+	});
+
+	test("--session before command is parsed correctly", () => {
+		const result = parseArgs(["--session", "mysession", "url"]);
+		expect(result).toEqual({
+			cmd: "url",
+			args: [],
+			timeout: undefined,
+			session: "mysession",
+			json: false,
+		});
+	});
+
+	test("--json before command is parsed correctly", () => {
+		const result = parseArgs(["--json", "status"]);
+		expect(result).toEqual({
+			cmd: "status",
+			args: [],
+			timeout: undefined,
+			session: undefined,
+			json: true,
+		});
+	});
+
+	test("all global flags before command", () => {
+		const result = parseArgs([
+			"--timeout",
+			"5000",
+			"--session",
+			"s1",
+			"--json",
+			"goto",
+			"https://example.com",
+		]);
+		expect(result).toEqual({
+			cmd: "goto",
+			args: ["https://example.com"],
+			timeout: 5000,
+			session: "s1",
+			json: true,
+		});
+	});
+
+	test("global flags mixed before and after command", () => {
+		const result = parseArgs([
+			"--timeout",
+			"3000",
+			"screenshot",
+			"--session",
+			"s2",
+			"/tmp/shot.png",
+		]);
+		expect(result).toEqual({
+			cmd: "screenshot",
+			args: ["/tmp/shot.png"],
+			timeout: 3000,
+			session: "s2",
+			json: false,
+		});
+	});
+
+	test("--config and --timeout both before command", () => {
+		const result = parseArgs([
+			"--config",
+			"/tmp/cfg.json",
+			"--timeout",
+			"8000",
+			"ping",
+		]);
+		expect(result).toEqual({
+			cmd: "ping",
+			args: [],
+			timeout: 8000,
+			session: undefined,
+			json: false,
+			config: "/tmp/cfg.json",
+		});
+	});
 });
 
 describe("formatOutput", () => {


### PR DESCRIPTION
## Summary
- Global flags (`--timeout`, `--session`, `--json`) now work when placed before the command name, matching the behaviour users expect from "Global flags" in the help text
- Previously, `browse --timeout 5000 ping` would fail with "Unknown command: --timeout" because the parser unconditionally treated the first arg as the command name
- The fix extracts all global flags from the full argv before identifying the command, consistent with how `--config` and `--listen` were already handled

Fixes #46

## Test plan
- [x] 6 new unit tests covering flags before command, after command, and mixed positions
- [x] All 717 existing tests pass
- [x] End-to-end verification with compiled binary: `browse --timeout 5000 ping`, `browse --json status`, `browse --session test ping` all work correctly