### PR TITLE
fix: allow spaces in flow variable interpolation syntax

### DIFF
--- a/src/flow-runner.ts
+++ b/src/flow-runner.ts
@@ -44,7 +44,7 @@ export function interpolateVars(
 	template: string,
 	vars: Record<string, string>,
 ): string {
-	return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+	return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, key) => {
 		return key in vars ? vars[key] : match;
 	});
 }

--- a/test/flow-runner.test.ts
+++ b/test/flow-runner.test.ts
@@ -89,6 +89,41 @@ describe("interpolateVars", () => {
 		const result = interpolateVars("{{key}}", {});
 		expect(result).toBe("{{key}}");
 	});
+
+	test("replaces {{ key }} with spaces inside braces", () => {
+		const result = interpolateVars("{{ base_url }}/login", {
+			base_url: "https://example.com",
+		});
+		expect(result).toBe("https://example.com/login");
+	});
+
+	test("replaces {{key }} with trailing space", () => {
+		const result = interpolateVars("{{url }}/page", {
+			url: "https://example.com",
+		});
+		expect(result).toBe("https://example.com/page");
+	});
+
+	test("replaces {{ key}} with leading space", () => {
+		const result = interpolateVars("{{ url}}/page", {
+			url: "https://example.com",
+		});
+		expect(result).toBe("https://example.com/page");
+	});
+
+	test("replaces spaced variables with multiple spaces", () => {
+		const result = interpolateVars("{{  url  }}/page", {
+			url: "https://example.com",
+		});
+		expect(result).toBe("https://example.com/page");
+	});
+
+	test("leaves unmatched spaced variables as literal", () => {
+		const result = interpolateVars("{{ known }} and {{ unknown }}", {
+			known: "OK",
+		});
+		expect(result).toBe("OK and {{ unknown }}");
+	});
 });
 
 // --- Helpers for runFlow tests ---


### PR DESCRIPTION
## Summary
- Updated the `interpolateVars` regex from `/\{\{(\w+)\}\}/g` to `/\{\{\s*(\w+)\s*\}\}/g` to accept optional whitespace inside braces
- `{{ var }}`, `{{var}}`, `{{ var}}`, `{{var }}`, and `{{  var  }}` all now interpolate correctly
- Unmatched spaced variables are left as literals (consistent with existing behaviour)

Closes #47

## Test plan
- [x] 5 new unit tests covering spaced, leading-space, trailing-space, multi-space, and unmatched spaced variable cases
- [x] All 80 flow-runner tests pass
- [x] Full test suite passes (722/722)
- [x] E2E script confirms `dryRunFlow` correctly interpolates `{{ url }}` to the substituted value
- [x] Binary rebuilt via `./setup.sh`