### PR TITLE
fix: capture console messages from user JavaScript via CDP

### DIFF
--- a/src/cdp-console.ts
+++ b/src/cdp-console.ts
@@ -1,0 +1,120 @@
+import type { CDPSession, Page } from "playwright";
+import type { RingBuffer } from "./buffers.ts";
+import type { ConsoleEntry } from "./commands/console.ts";
+
+/**
+ * CDP Runtime.consoleAPICalled event argument shape.
+ */
+interface CDPRemoteObject {
+	type: string;
+	value?: unknown;
+	description?: string;
+	className?: string;
+}
+
+interface CDPConsoleEvent {
+	type: string;
+	args: CDPRemoteObject[];
+	stackTrace?: {
+		callFrames: Array<{
+			url: string;
+			lineNumber: number;
+			columnNumber: number;
+		}>;
+	};
+}
+
+interface CDPLogEvent {
+	entry: {
+		level: string;
+		text: string;
+		source: string;
+		url?: string;
+		lineNumber?: number;
+	};
+}
+
+/**
+ * Convert a CDP RemoteObject to a display string.
+ */
+function remoteObjectToString(arg: CDPRemoteObject): string {
+	if (arg.value !== undefined) return String(arg.value);
+	if (arg.description !== undefined) return arg.description;
+	return arg.type;
+}
+
+/**
+ * Handle a CDP Runtime.consoleAPICalled event, pushing
+ * the message into the provided ring buffer.
+ */
+export function handleCDPConsoleEvent(
+	event: CDPConsoleEvent,
+	buffer: RingBuffer<ConsoleEntry>,
+): void {
+	const text = event.args.map(remoteObjectToString).join(" ");
+	const frame = event.stackTrace?.callFrames?.[0];
+	buffer.push({
+		level: event.type,
+		text,
+		location: {
+			url: frame?.url ?? "",
+			lineNumber: frame?.lineNumber ?? 0,
+			columnNumber: frame?.columnNumber ?? 0,
+		},
+		timestamp: Date.now(),
+	});
+}
+
+/**
+ * Handle a CDP Log.entryAdded event, pushing the entry
+ * into the provided ring buffer (skips worker sources).
+ */
+export function handleCDPLogEvent(
+	event: CDPLogEvent,
+	buffer: RingBuffer<ConsoleEntry>,
+): void {
+	const { level, text, source, url, lineNumber } = event.entry;
+	if (source === "worker") return;
+	buffer.push({
+		level,
+		text,
+		location: {
+			url: url ?? "",
+			lineNumber: lineNumber ?? 0,
+			columnNumber: 0,
+		},
+		timestamp: Date.now(),
+	});
+}
+
+/**
+ * Attach a CDP session to a page and enable Runtime + Log domains
+ * so that console messages from user JavaScript are captured.
+ *
+ * Patchright (the Playwright fork used by browse) omits the
+ * `Runtime.enable` call that standard Playwright makes, which
+ * prevents execution-context tracking and silently drops all
+ * Runtime.consoleAPICalled events. This function works around
+ * that by opening our own CDP session and forwarding events
+ * directly into the ring buffer.
+ *
+ * Returns the CDP session so callers can detach it if needed.
+ */
+export async function attachCDPConsoleCapture(
+	page: Page,
+	buffer: RingBuffer<ConsoleEntry>,
+): Promise<CDPSession> {
+	const client = await page.context().newCDPSession(page);
+	await client.send("Runtime.enable");
+	await client.send("Log.enable");
+
+	client.on("Runtime.consoleAPICalled", (event: CDPConsoleEvent) => {
+		handleCDPConsoleEvent(event, buffer);
+	});
+
+	client.on("Log.entryAdded", (event: CDPLogEvent) => {
+		handleCDPLogEvent(event, buffer);
+	});
+
+	return client;
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { type BrowserContext, chromium, type Page } from "playwright";
 import { cleanupToken, generateToken } from "./auth.ts";
 import { RingBuffer } from "./buffers.ts";
+import { attachCDPConsoleCapture } from "./cdp-console.ts";
 import { handleA11y } from "./commands/a11y.ts";
 import { handleAssert } from "./commands/assert.ts";
 import { handleAssertAi } from "./commands/assert-ai.ts";
@@ -197,12 +198,20 @@ function attachPageListeners(page: Page, tabState: TabState): void {
 		}
 	});
 
-	page.on("console", (msg) => {
-		tabState.consoleBuffer.push({
-			level: msg.type(),
-			text: msg.text(),
-			location: msg.location(),
-			timestamp: Date.now(),
+	// Console capture via CDP — Patchright omits the Runtime.enable call
+	// that standard Playwright makes, silently dropping all
+	// Runtime.consoleAPICalled events. attachCDPConsoleCapture opens its
+	// own CDP session with Runtime + Log enabled so user-triggered
+	// console.log/warn/error messages are captured reliably.
+	attachCDPConsoleCapture(page, tabState.consoleBuffer).catch(() => {
+		// Fallback: if CDP session fails, use Playwright's (partial) listener
+		page.on("console", (msg) => {
+			tabState.consoleBuffer.push({
+				level: msg.type(),
+				text: msg.text(),
+				location: msg.location(),
+				timestamp: Date.now(),
+			});
 		});
 	});
 

--- a/test/console.test.ts
+++ b/test/console.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { RingBuffer } from "../src/buffers.ts";
 import {
+	handleCDPConsoleEvent,
+	handleCDPLogEvent,
+} from "../src/cdp-console.ts";
+import {
 	type ConsoleEntry,
 	formatConsoleEntries,
 	handleConsole,
@@ -182,5 +186,229 @@ describe("formatConsoleEntries", () => {
 		];
 		const formatted = formatConsoleEntries(entries);
 		expect(formatted).toContain("\n\n");
+	});
+});
+
+describe("CDP console capture", () => {
+	let buffer: RingBuffer<ConsoleEntry>;
+
+	beforeEach(() => {
+		buffer = new RingBuffer<ConsoleEntry>(500);
+	});
+
+	describe("handleCDPConsoleEvent", () => {
+		test("captures console.log with string argument", () => {
+			handleCDPConsoleEvent(
+				{
+					type: "log",
+					args: [{ type: "string", value: "Hello world" }],
+					stackTrace: {
+						callFrames: [
+							{
+								url: "https://example.com/app.js",
+								lineNumber: 10,
+								columnNumber: 5,
+							},
+						],
+					},
+				},
+				buffer,
+			);
+
+			const entries = buffer.peek();
+			expect(entries).toHaveLength(1);
+			expect(entries[0].level).toBe("log");
+			expect(entries[0].text).toBe("Hello world");
+			expect(entries[0].location.url).toBe("https://example.com/app.js");
+			expect(entries[0].location.lineNumber).toBe(10);
+			expect(entries[0].location.columnNumber).toBe(5);
+		});
+
+		test("captures console.warn", () => {
+			handleCDPConsoleEvent(
+				{
+					type: "warning",
+					args: [{ type: "string", value: "Warning message" }],
+					stackTrace: { callFrames: [] },
+				},
+				buffer,
+			);
+
+			const entries = buffer.peek();
+			expect(entries).toHaveLength(1);
+			expect(entries[0].level).toBe("warning");
+			expect(entries[0].text).toBe("Warning message");
+		});
+
+		test("captures console.error", () => {
+			handleCDPConsoleEvent(
+				{
+					type: "error",
+					args: [{ type: "string", value: "Error message" }],
+					stackTrace: { callFrames: [] },
+				},
+				buffer,
+			);
+
+			const entries = buffer.peek();
+			expect(entries).toHaveLength(1);
+			expect(entries[0].level).toBe("error");
+			expect(entries[0].text).toBe("Error message");
+		});
+
+		test("joins multiple arguments with spaces", () => {
+			handleCDPConsoleEvent(
+				{
+					type: "log",
+					args: [
+						{ type: "string", value: "count:" },
+						{ type: "number", value: 42, description: "42" },
+					],
+					stackTrace: { callFrames: [] },
+				},
+				buffer,
+			);
+
+			const entries = buffer.peek();
+			expect(entries[0].text).toBe("count: 42");
+		});
+
+		test("uses description for object arguments", () => {
+			handleCDPConsoleEvent(
+				{
+					type: "log",
+					args: [
+						{
+							type: "object",
+							description: "Object",
+							className: "Object",
+						},
+					],
+					stackTrace: { callFrames: [] },
+				},
+				buffer,
+			);
+
+			const entries = buffer.peek();
+			expect(entries[0].text).toBe("Object");
+		});
+
+		test("handles missing stackTrace gracefully", () => {
+			handleCDPConsoleEvent(
+				{
+					type: "log",
+					args: [{ type: "string", value: "no stack" }],
+				},
+				buffer,
+			);
+
+			const entries = buffer.peek();
+			expect(entries).toHaveLength(1);
+			expect(entries[0].text).toBe("no stack");
+			expect(entries[0].location.url).toBe("");
+			expect(entries[0].location.lineNumber).toBe(0);
+		});
+
+		test("handles empty args array", () => {
+			handleCDPConsoleEvent(
+				{
+					type: "log",
+					args: [],
+					stackTrace: { callFrames: [] },
+				},
+				buffer,
+			);
+
+			const entries = buffer.peek();
+			expect(entries).toHaveLength(1);
+			expect(entries[0].text).toBe("");
+		});
+
+		test("uses value for boolean and undefined args", () => {
+			handleCDPConsoleEvent(
+				{
+					type: "log",
+					args: [{ type: "boolean", value: true }, { type: "undefined" }],
+					stackTrace: { callFrames: [] },
+				},
+				buffer,
+			);
+
+			const entries = buffer.peek();
+			expect(entries[0].text).toBe("true undefined");
+		});
+
+		test("prefers value over description for primitives", () => {
+			handleCDPConsoleEvent(
+				{
+					type: "log",
+					args: [{ type: "number", value: 3.14, description: "3.14" }],
+					stackTrace: { callFrames: [] },
+				},
+				buffer,
+			);
+
+			const entries = buffer.peek();
+			expect(entries[0].text).toBe("3.14");
+		});
+	});
+
+	describe("handleCDPLogEvent", () => {
+		test("captures resource errors", () => {
+			handleCDPLogEvent(
+				{
+					entry: {
+						level: "error",
+						text: "Failed to load resource: 404",
+						source: "network",
+						url: "https://example.com/missing.js",
+						lineNumber: 0,
+					},
+				},
+				buffer,
+			);
+
+			const entries = buffer.peek();
+			expect(entries).toHaveLength(1);
+			expect(entries[0].level).toBe("error");
+			expect(entries[0].text).toBe("Failed to load resource: 404");
+			expect(entries[0].location.url).toBe("https://example.com/missing.js");
+		});
+
+		test("ignores worker source entries", () => {
+			handleCDPLogEvent(
+				{
+					entry: {
+						level: "error",
+						text: "Worker error",
+						source: "worker",
+						url: "",
+						lineNumber: 0,
+					},
+				},
+				buffer,
+			);
+
+			const entries = buffer.peek();
+			expect(entries).toHaveLength(0);
+		});
+
+		test("handles missing url and lineNumber", () => {
+			handleCDPLogEvent(
+				{
+					entry: {
+						level: "warning",
+						text: "Deprecation warning",
+						source: "deprecation",
+					},
+				},
+				buffer,
+			);
+
+			const entries = buffer.peek();
+			expect(entries).toHaveLength(1);
+			expect(entries[0].location.url).toBe("");
+			expect(entries[0].location.lineNumber).toBe(0);
+		});
 	});
 });

--- a/test/fixtures/console-test.html
+++ b/test/fixtures/console-test.html
@@ -15,6 +15,10 @@
   </div>
   <p>This page logs messages at various levels and fetches endpoints that fail.</p>
 
+  <button type="button" onclick="console.log('Log from click')">Log</button>
+  <button type="button" onclick="console.warn('Warning from click')">Warn</button>
+  <button type="button" onclick="console.error('Error from click')">Error</button>
+
   <script>
     // Log messages at various levels
     console.log("Page loaded successfully");


### PR DESCRIPTION
## Summary

- **Root cause**: Patchright (the Playwright fork used by browse) removes the `Runtime.enable` CDP call that standard Playwright makes during page initialisation. Without it, Chrome never sends `Runtime.executionContextCreated` events, so the internal `_contextIdToContext` map stays empty and `_onConsoleAPI` silently drops all `Runtime.consoleAPICalled` events. Only `Log.entryAdded` events (resource errors) still work because `_onLogEntryAdded` doesn't need execution contexts.
- **Fix**: Opens a dedicated CDP session per page with `Runtime.enable` and `Log.enable`, capturing `Runtime.consoleAPICalled` and `Log.entryAdded` events directly into the ring buffer — bypassing Playwright's broken listener entirely. Falls back to `page.on("console")` if the CDP session fails.
- Added `src/cdp-console.ts` with testable event handlers and the CDP session attachment function
- Added interactive console buttons to the test fixture HTML for manual verification
- 10 new unit tests covering CDP console and log event handling

## Test plan

- [x] All 751 existing tests pass
- [x] 10 new unit tests for `handleCDPConsoleEvent` and `handleCDPLogEvent`
- [x] Built binary with `./setup.sh`
- [x] E2E: `browse goto` to page with buttons, `browse click` each button, `browse console --keep` shows all three user-triggered messages (log, warning, error)
- [x] E2E: Page-load console messages still captured
- [x] E2E: JSON output (`--json`) works correctly

Closes #50