### PR TITLE
fix: run benchmark on temporary page to prevent history pollution

### DIFF
--- a/src/commands/benchmark.ts
+++ b/src/commands/benchmark.ts
@@ -1,11 +1,11 @@
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Page } from "playwright";
+import type { BrowserContext } from "playwright";
 import type { Response } from "../protocol.ts";
 import { assignRefs, parseAriaSnapshot } from "../refs.ts";
 
 export type BenchmarkDeps = {
-	page: Page;
+	context: BrowserContext;
 };
 
 const TEST_PAGE = `data:text/html,<html><body>
@@ -76,9 +76,13 @@ export async function handleBenchmark(
 	deps: BenchmarkDeps,
 	args: string[],
 ): Promise<Response> {
-	const { page } = deps;
+	const { context } = deps;
 	const iterations = parseIterations(args);
 	const screenshotPath = join(tmpdir(), "browse-benchmark.png");
+
+	// Create a temporary page so benchmark navigation doesn't pollute
+	// the main page's history stack (see issue #52).
+	const page = await context.newPage();
 
 	try {
 		// Navigate to test page
@@ -131,5 +135,7 @@ export async function handleBenchmark(
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		return { ok: false, error: `Benchmark failed: ${message}` };
+	} finally {
+		await page.close().catch(() => {});
 	}
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -648,7 +648,7 @@ export async function startServer(
 							json: request.json,
 						});
 					case "benchmark":
-						return handleBenchmark({ page }, request.args);
+						return handleBenchmark({ context: sessionContext }, request.args);
 					case "dialog":
 						return handleDialog(session.dialogState, request.args);
 					case "download":

--- a/test/integration/benchmark.test.ts
+++ b/test/integration/benchmark.test.ts
@@ -36,6 +36,7 @@ function mockPage(overrides: Record<string, unknown> = {}) {
 			ariaSnapshot: mock(() => Promise.resolve('- button "Test"')),
 		})),
 		evaluate: mock(() => Promise.resolve(500)),
+		close: mock(() => Promise.resolve()),
 		...overrides,
 	} as never;
 }
@@ -151,6 +152,73 @@ describe("integration: benchmark", () => {
 				expect(response.data).toContain("p95:");
 				expect(response.data).toContain("p99:");
 			}
+		} finally {
+			await shutdown();
+		}
+	});
+
+	test("back navigates correctly after benchmark (issue #52)", async () => {
+		const config = testPaths();
+		const history: string[] = [];
+		let currentIndex = -1;
+
+		const page = mockPage({
+			goto: mock((url: string) => {
+				// Trim history forward on new navigation (browser behaviour)
+				history.splice(currentIndex + 1);
+				history.push(url);
+				currentIndex = history.length - 1;
+				return Promise.resolve();
+			}),
+			goBack: mock(() => {
+				if (currentIndex <= 0) return Promise.resolve(null);
+				currentIndex--;
+				return Promise.resolve({});
+			}),
+			title: mock(() => {
+				const url = history[currentIndex] ?? "";
+				return Promise.resolve(`Title: ${url}`);
+			}),
+			url: mock(() => history[currentIndex] ?? "about:blank"),
+		});
+
+		// The context's newPage returns a separate temp page for benchmark
+		const tempPage = mockPage();
+		const ctx = mockContext({
+			newPage: mock(() => Promise.resolve(tempPage)),
+		});
+
+		const { shutdown } = await startServer(
+			{ page, context: ctx, config: null },
+			config,
+			async () => {},
+		);
+
+		try {
+			// Navigate to two pages
+			await sendCommand(config.socketPath, "goto", [
+				"https://page1.example.com",
+			]);
+			await sendCommand(config.socketPath, "goto", [
+				"https://page2.example.com",
+			]);
+
+			// Run benchmark — should NOT affect main page's history
+			const benchResult = await sendCommand(config.socketPath, "benchmark", [
+				"--iterations",
+				"1",
+			]);
+			expect(benchResult.ok).toBe(true);
+
+			// Back should return to page1, not a data:text/html benchmark page
+			const backResult = await sendCommand(config.socketPath, "back");
+			expect(backResult.ok).toBe(true);
+			if (backResult.ok) {
+				expect(backResult.data).toContain("page1.example.com");
+			}
+
+			// Main page's goto should only have been called for the two user navigations
+			expect(page.goto).toHaveBeenCalledTimes(2);
 		} finally {
 			await shutdown();
 		}

--- a/test/unit/benchmark.test.ts
+++ b/test/unit/benchmark.test.ts
@@ -74,17 +74,24 @@ describe("formatBenchmarkResults", () => {
 });
 
 describe("handleBenchmark", () => {
-	function makeDeps(): BenchmarkDeps {
+	function mockTempPage() {
 		return {
-			page: {
-				goto: mock(() => Promise.resolve()),
-				title: mock(() => Promise.resolve("Test")),
-				screenshot: mock(() => Promise.resolve(Buffer.from(""))),
-				locator: mock(() => ({
-					click: mock(() => Promise.resolve()),
-					fill: mock(() => Promise.resolve()),
-					ariaSnapshot: mock(() => Promise.resolve('- button "Test"')),
-				})),
+			goto: mock(() => Promise.resolve()),
+			title: mock(() => Promise.resolve("Test")),
+			screenshot: mock(() => Promise.resolve(Buffer.from(""))),
+			locator: mock(() => ({
+				click: mock(() => Promise.resolve()),
+				fill: mock(() => Promise.resolve()),
+				ariaSnapshot: mock(() => Promise.resolve('- button "Test"')),
+			})),
+			close: mock(() => Promise.resolve()),
+		};
+	}
+
+	function makeDeps(tempPage = mockTempPage()): BenchmarkDeps {
+		return {
+			context: {
+				newPage: mock(() => Promise.resolve(tempPage)),
 			} as never,
 		};
 	}
@@ -130,5 +137,53 @@ describe("handleBenchmark", () => {
 		if (result.ok) {
 			expect(result.data).toContain("3 iterations");
 		}
+	});
+
+	test("uses a temporary page from context, not the main page", async () => {
+		const tempPage = {
+			goto: mock(() => Promise.resolve()),
+			screenshot: mock(() => Promise.resolve(Buffer.from(""))),
+			locator: mock(() => ({
+				click: mock(() => Promise.resolve()),
+				fill: mock(() => Promise.resolve()),
+				ariaSnapshot: mock(() => Promise.resolve('- button "Test"')),
+			})),
+			close: mock(() => Promise.resolve()),
+		};
+		const contextMock = {
+			newPage: mock(() => Promise.resolve(tempPage)),
+		};
+		const deps: BenchmarkDeps = {
+			context: contextMock as never,
+		};
+
+		const result = await handleBenchmark(deps, ["--iterations", "2"]);
+
+		expect(result.ok).toBe(true);
+		// Should have created a new page from context
+		expect(contextMock.newPage).toHaveBeenCalled();
+		// Should have used the temp page for navigation
+		expect(tempPage.goto).toHaveBeenCalled();
+		// Should have closed the temp page after benchmark
+		expect(tempPage.close).toHaveBeenCalled();
+	});
+
+	test("closes temporary page even when benchmark fails", async () => {
+		const tempPage = {
+			goto: mock(() => Promise.reject(new Error("goto failed"))),
+			close: mock(() => Promise.resolve()),
+		};
+		const contextMock = {
+			newPage: mock(() => Promise.resolve(tempPage)),
+		};
+		const deps: BenchmarkDeps = {
+			context: contextMock as never,
+		};
+
+		const result = await handleBenchmark(deps, ["--iterations", "1"]);
+
+		expect(result.ok).toBe(false);
+		// Must close temp page even on failure
+		expect(tempPage.close).toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

- Benchmark now creates a temporary page from the browser context instead of reusing the active page, preventing `data:text/html` navigation entries from polluting the history stack
- The temporary page is closed in a `finally` block, ensuring cleanup even on failure
- The `back` command now reliably returns to the correct previous page after benchmark has been used

Closes #52

## Test plan

- [x] Unit test: benchmark creates and closes a temporary page from context
- [x] Unit test: temporary page is closed even when benchmark fails
- [x] Integration test: `goto page1 → goto page2 → benchmark → back` returns to page1
- [x] Existing benchmark unit and integration tests updated and passing
- [x] Binary built and verified E2E: `goto example.com → goto httpbin.org → benchmark → back` navigated to `example.com`