### PR TITLE
fix: normalise form field keys and add placeholder fallback

### DIFF
--- a/src/commands/form.ts
+++ b/src/commands/form.ts
@@ -6,6 +6,12 @@ const FILLABLE_ROLES = ["textbox", "searchbox", "spinbutton", "combobox"];
 const SELECTABLE_ROLES = ["combobox", "listbox"];
 const CHECKABLE_ROLES = ["checkbox", "radio", "switch"];
 
+/** Strip trailing colons/punctuation and trim whitespace so users can write
+ *  keys like "Username:" or " Email " and still match the accessible name. */
+function normaliseKey(key: string): string {
+	return key.replace(/[:]+$/, "").trim();
+}
+
 /**
  * Bulk form fill: fill multiple fields in one command.
  *
@@ -77,6 +83,7 @@ export async function handleForm(
 	const errors: string[] = [];
 
 	for (const [fieldName, value] of Object.entries(data)) {
+		const matchName = normaliseKey(fieldName);
 		try {
 			if (typeof value === "boolean") {
 				// Handle checkbox/switch/radio
@@ -84,7 +91,7 @@ export async function handleForm(
 				for (const role of CHECKABLE_ROLES) {
 					const locator = page.getByRole(
 						role as Parameters<Page["getByRole"]>[0],
-						{ name: fieldName },
+						{ name: matchName },
 					);
 					if ((await locator.count()) > 0) {
 						if (value) {
@@ -111,7 +118,7 @@ export async function handleForm(
 			for (const role of FILLABLE_ROLES) {
 				const locator = page.getByRole(
 					role as Parameters<Page["getByRole"]>[0],
-					{ name: fieldName },
+					{ name: matchName },
 				);
 				if ((await locator.count()) > 0) {
 					await locator.first().fill(String(value), { timeout: 5_000 });
@@ -127,7 +134,7 @@ export async function handleForm(
 			for (const role of SELECTABLE_ROLES) {
 				const locator = page.getByRole(
 					role as Parameters<Page["getByRole"]>[0],
-					{ name: fieldName },
+					{ name: matchName },
 				);
 				if ((await locator.count()) > 0) {
 					await locator.first().selectOption(String(value), { timeout: 5_000 });
@@ -140,7 +147,7 @@ export async function handleForm(
 			if (fieldFilled) continue;
 
 			// Try by label as fallback
-			const labelLocator = page.getByLabel(fieldName);
+			const labelLocator = page.getByLabel(matchName);
 			if ((await labelLocator.count()) > 0) {
 				const tagName = await labelLocator
 					.first()
@@ -153,6 +160,26 @@ export async function handleForm(
 				} else {
 					await labelLocator.first().fill(String(value), { timeout: 5_000 });
 					filled.push(`${fieldName}: "${value}" (by label)`);
+				}
+				continue;
+			}
+
+			// Try by placeholder as final fallback
+			const placeholderLocator = page.getByPlaceholder(matchName);
+			if ((await placeholderLocator.count()) > 0) {
+				const tagName = await placeholderLocator
+					.first()
+					.evaluate((el) => el.tagName.toLowerCase());
+				if (tagName === "select") {
+					await placeholderLocator
+						.first()
+						.selectOption(String(value), { timeout: 5_000 });
+					filled.push(`${fieldName}: "${value}" (select by placeholder)`);
+				} else {
+					await placeholderLocator
+						.first()
+						.fill(String(value), { timeout: 5_000 });
+					filled.push(`${fieldName}: "${value}" (by placeholder)`);
 				}
 				continue;
 			}

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, mock, test } from "bun:test";
+import { handleForm } from "../src/commands/form.ts";
+
+/**
+ * Creates a mock Page that simulates Playwright locator methods.
+ *
+ * `fields` maps accessible names → { role, tagName }.
+ * `labels` maps label text → { tagName }.
+ * `placeholders` maps placeholder text → { tagName }.
+ *
+ * getByRole matches when role AND name both match a field entry.
+ * getByLabel matches when the label text matches a labels entry.
+ * getByPlaceholder matches when the placeholder text matches a placeholders entry.
+ */
+function mockFormPage(
+	fields: Record<string, { role: string; tagName?: string }> = {},
+	labels: Record<string, { tagName?: string }> = {},
+	placeholders: Record<string, { tagName?: string }> = {},
+) {
+	return {
+		getByRole: mock((role: string, opts?: { name?: string }) => {
+			const name = opts?.name;
+			// Find a field whose accessible name matches AND whose role matches
+			const match =
+				name &&
+				Object.entries(fields).find(
+					([fieldName, f]) =>
+						f.role === role && fieldName.toLowerCase() === name.toLowerCase(),
+				);
+			return {
+				count: mock(() => Promise.resolve(match ? 1 : 0)),
+				first: mock(() => ({
+					fill: mock(() => Promise.resolve()),
+					selectOption: mock(() => Promise.resolve()),
+					check: mock(() => Promise.resolve()),
+					uncheck: mock(() => Promise.resolve()),
+					evaluate: mock(() =>
+						Promise.resolve(match ? (match[1].tagName ?? "input") : "input"),
+					),
+				})),
+			};
+		}),
+		getByLabel: mock((label: string) => {
+			const match = Object.entries(labels).find(
+				([l]) => l.toLowerCase() === label.toLowerCase(),
+			);
+			return {
+				count: mock(() => Promise.resolve(match ? 1 : 0)),
+				first: mock(() => ({
+					fill: mock(() => Promise.resolve()),
+					selectOption: mock(() => Promise.resolve()),
+					evaluate: mock(() =>
+						Promise.resolve(match ? (match[1].tagName ?? "input") : "input"),
+					),
+				})),
+			};
+		}),
+		getByPlaceholder: mock((placeholder: string) => {
+			const match = Object.entries(placeholders).find(
+				([p]) => p.toLowerCase() === placeholder.toLowerCase(),
+			);
+			return {
+				count: mock(() => Promise.resolve(match ? 1 : 0)),
+				first: mock(() => ({
+					fill: mock(() => Promise.resolve()),
+					selectOption: mock(() => Promise.resolve()),
+					evaluate: mock(() =>
+						Promise.resolve(match ? (match[1].tagName ?? "input") : "input"),
+					),
+				})),
+			};
+		}),
+	} as never;
+}
+
+describe("handleForm", () => {
+	// ── Argument validation ──────────────────────────────────────────
+
+	test("returns error when --data is missing", async () => {
+		const page = mockFormPage();
+		const result = await handleForm(page, []);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("Usage");
+	});
+
+	test("returns error for invalid JSON", async () => {
+		const page = mockFormPage();
+		const result = await handleForm(page, ["--data", "not-json"]);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("Invalid JSON");
+	});
+
+	test("returns error for non-object JSON", async () => {
+		const page = mockFormPage();
+		const result = await handleForm(page, ["--data", "[1,2,3]"]);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("must be a JSON object");
+	});
+
+	test("returns error for unknown flags", async () => {
+		const page = mockFormPage();
+		const result = await handleForm(page, ["--data", '{"x":"y"}', "--bogus"]);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("Unknown flag");
+	});
+
+	// ── Role-based matching (existing behaviour) ─────────────────────
+
+	test("fills a textbox matched by accessible name", async () => {
+		const page = mockFormPage({ Username: { role: "textbox" } });
+		const result = await handleForm(page, [
+			"--data",
+			'{"Username":"testuser"}',
+		]);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toContain("Username");
+			expect(result.data).toContain("textbox");
+		}
+	});
+
+	test("checks a checkbox matched by accessible name", async () => {
+		const page = mockFormPage({ Subscribe: { role: "checkbox" } });
+		const result = await handleForm(page, ["--data", '{"Subscribe":true}']);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toContain("Subscribe");
+			expect(result.data).toContain("checkbox");
+		}
+	});
+
+	// ── Label fallback (existing behaviour) ──────────────────────────
+
+	test("fills via getByLabel when role matching misses", async () => {
+		const page = mockFormPage({}, { Email: { tagName: "input" } });
+		const result = await handleForm(page, ["--data", '{"Email":"a@b.com"}']);
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.data).toContain("by label");
+	});
+
+	// ── Key normalisation: trailing colon ────────────────────────────
+
+	test("strips trailing colon from field key before matching", async () => {
+		const page = mockFormPage({ Username: { role: "textbox" } });
+		const result = await handleForm(page, [
+			"--data",
+			'{"Username:":"testuser"}',
+		]);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toContain("Username:");
+			expect(result.data).toContain("textbox");
+		}
+	});
+
+	test("strips trailing colon from boolean field key", async () => {
+		const page = mockFormPage({ "Remember me": { role: "checkbox" } });
+		const result = await handleForm(page, ["--data", '{"Remember me:":true}']);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toContain("Remember me:");
+			expect(result.data).toContain("checkbox");
+		}
+	});
+
+	// ── Key normalisation: whitespace ────────────────────────────────
+
+	test("trims whitespace from field key before matching", async () => {
+		const page = mockFormPage({ Email: { role: "textbox" } });
+		const result = await handleForm(page, ["--data", '{" Email ":"a@b.com"}']);
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.data).toContain("textbox");
+	});
+
+	// ── Placeholder fallback ─────────────────────────────────────────
+
+	test("fills via getByPlaceholder when role and label both miss", async () => {
+		const page = mockFormPage(
+			{},
+			{},
+			{ "Enter your email": { tagName: "input" } },
+		);
+		const result = await handleForm(page, [
+			"--data",
+			'{"Enter your email":"a@b.com"}',
+		]);
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.data).toContain("by placeholder");
+	});
+
+	test("fills via getByPlaceholder for normalised key", async () => {
+		const page = mockFormPage({}, {}, { "Search here": { tagName: "input" } });
+		const result = await handleForm(page, [
+			"--data",
+			'{"Search here:":"query"}',
+		]);
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.data).toContain("by placeholder");
+	});
+
+	// ── Error when nothing matches ───────────────────────────────────
+
+	test("reports error with original key when no matching field found", async () => {
+		const page = mockFormPage();
+		const result = await handleForm(page, ["--data", '{"Nonexistent:":"val"}']);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("Nonexistent:");
+			expect(result.error).toContain("no matching form field found");
+		}
+	});
+
+	// ── Mixed success / failure ──────────────────────────────────────
+
+	test("reports partial failure when some fields match and others don't", async () => {
+		const page = mockFormPage({ Username: { role: "textbox" } });
+		const result = await handleForm(page, [
+			"--data",
+			'{"Username":"user","Missing":"val"}',
+		]);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("✓ Username");
+			expect(result.error).toContain("✗ Missing");
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- **Normalise field keys** before matching: strip trailing colons and trim whitespace, so `"Username:"` and `" Email "` resolve correctly against accessible names
- **Add `getByPlaceholder` fallback**: when `getByRole` and `getByLabel` both miss, try matching by placeholder text — useful for fields with no label element
- Original user-supplied keys are preserved in output messages for clarity

Closes #54

## Test plan

- [x] Unit tests: 14 tests in `test/form.test.ts` covering argument validation, role matching, label fallback, key normalisation (colon + whitespace), placeholder fallback, and error reporting
- [x] Full regression: existing test suite passes (120 tests across related files)
- [x] Binary built with `./setup.sh` and E2E-tested against a real HTML form:
  - `{"Username:":"testuser"}` → fills correctly (was failing before)
  - `{"Username":"testuser"}` → still works (regression safe)
  - `{"Search here":"query"}` → matches by placeholder
  - `{" Email ":"a@b.com","Subscribe:":true}` → whitespace + boolean colon
  - `{"Nonexistent:":"val"}` → still reports error with original key