### PR TITLE
fix: report validation error instead of 'not found' for invalid config

### DIFF
--- a/src/commands/flow.ts
+++ b/src/commands/flow.ts
@@ -1,6 +1,6 @@
 import type { Page } from "playwright";
 import type { RingBuffer } from "../buffers.ts";
-import type { BrowseConfig } from "../config.ts";
+import type { BrowseConfig, ConfigContext } from "../config.ts";
 import {
 	dryRunFlow,
 	formatFlowReport,
@@ -23,11 +23,14 @@ export async function handleFlow(
 	page: Page,
 	args: string[],
 	deps?: FlowDeps,
+	configCtx?: ConfigContext,
 ): Promise<Response> {
 	if (!config) {
 		return {
 			ok: false,
-			error: "No browse.config.json found. Create one with flow definitions.",
+			error:
+				configCtx?.configError ??
+				"No browse.config.json found. Create one with flow definitions.",
 		};
 	}
 

--- a/src/commands/healthcheck.ts
+++ b/src/commands/healthcheck.ts
@@ -3,7 +3,11 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { BrowserContext, Page } from "playwright";
 import type { RingBuffer } from "../buffers.ts";
-import type { AssertCondition, BrowseConfig } from "../config.ts";
+import type {
+	AssertCondition,
+	BrowseConfig,
+	ConfigContext,
+} from "../config.ts";
 import { interpolateVars, parseVars } from "../flow-runner.ts";
 import type { Response } from "../protocol.ts";
 import { formatHealthcheckJUnit } from "../reporters.ts";
@@ -109,11 +113,14 @@ export async function handleHealthcheck(
 	args: string[],
 	deps: HealthcheckDeps | null,
 	context?: BrowserContext,
+	configCtx?: ConfigContext,
 ): Promise<Response> {
 	if (!config) {
 		return {
 			ok: false,
-			error: "No browse.config.json found. Create one with healthcheck pages.",
+			error:
+				configCtx?.configError ??
+				"No browse.config.json found. Create one with healthcheck pages.",
 		};
 	}
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,5 +1,9 @@
 import type { Page } from "playwright";
-import type { BrowseConfig, EnvironmentConfig } from "../config.ts";
+import type {
+	BrowseConfig,
+	ConfigContext,
+	EnvironmentConfig,
+} from "../config.ts";
 import type { Response } from "../protocol.ts";
 import { compileSafePattern } from "../safe-pattern.ts";
 
@@ -11,11 +15,13 @@ export async function handleLogin(
 	config: BrowseConfig | null,
 	page: Page,
 	args: string[],
+	configCtx?: ConfigContext,
 ): Promise<Response> {
 	if (!config) {
 		return {
 			ok: false,
 			error:
+				configCtx?.configError ??
 				"No browse.config.json found. Create one with login environments or use goto + fill + click manually.",
 		};
 	}

--- a/src/commands/test-matrix.ts
+++ b/src/commands/test-matrix.ts
@@ -1,6 +1,6 @@
 import type { BrowserContext, Page } from "playwright";
 import { RingBuffer } from "../buffers.ts";
-import type { BrowseConfig } from "../config.ts";
+import type { BrowseConfig, ConfigContext } from "../config.ts";
 import type { StealthOpts } from "../daemon.ts";
 import { parseVars, runFlow, type StepResult } from "../flow-runner.ts";
 import type { Response } from "../protocol.ts";
@@ -39,11 +39,13 @@ export async function handleTestMatrix(
 	_sessionContext: BrowserContext,
 	defaultContext: BrowserContext,
 	stealthOpts?: StealthOpts,
+	configCtx?: ConfigContext,
 ): Promise<Response> {
 	if (!config) {
 		return {
 			ok: false,
 			error:
+				configCtx?.configError ??
 				"No browse.config.json found. Create one with flow and environment definitions.",
 		};
 	}

--- a/src/config.ts
+++ b/src/config.ts
@@ -96,6 +96,11 @@ export type BrowseConfig = {
 	timeout?: number;
 };
 
+/** Passed alongside config so commands can distinguish "not found" from "invalid". */
+export type ConfigContext = {
+	configError?: string | null;
+};
+
 /**
  * Resolve the config file path using the following precedence:
  * 1. Explicit path (from --config flag)

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -185,6 +185,8 @@ export type ServerDeps = {
 	page: Page;
 	context: BrowserContext;
 	config: BrowseConfig | null;
+	/** Validation error when config file exists but is invalid. */
+	configError?: string | null;
 	stealthOpts?: StealthOpts;
 	token?: string;
 	/** Optional TCP listen address, e.g. "tcp://0.0.0.0:9222" */
@@ -247,7 +249,8 @@ export async function startServer(
 	let server: Server;
 	let idleTimer: IdleTimer;
 
-	const { context, config, stealthOpts, token, tcpListen } = deps;
+	const { context, config, configError, stealthOpts, token, tcpListen } = deps;
+	const configCtx = configError ? { configError } : undefined;
 	const exitFn = options?.onExit ?? (() => process.exit(0));
 	const startTime = Date.now();
 
@@ -593,17 +596,23 @@ export async function startServer(
 					case "auth-state":
 						return handleAuthState(sessionContext, page, request.args);
 					case "login":
-						return handleLogin(config, page, request.args);
+						return handleLogin(config, page, request.args, configCtx);
 					case "tab":
 						return handleTab(tabRegistry, request.args, {
 							clearRefs,
 							createTab: () => createTab(sessionContext),
 						});
 					case "flow":
-						return handleFlow(config, page, request.args, {
-							consoleBuffer: getActiveConsoleBuffer(session),
-							networkBuffer: getActiveNetworkBuffer(session),
-						});
+						return handleFlow(
+							config,
+							page,
+							request.args,
+							{
+								consoleBuffer: getActiveConsoleBuffer(session),
+								networkBuffer: getActiveNetworkBuffer(session),
+							},
+							configCtx,
+						);
 					case "assert":
 						return handleAssert(config, page, request.args);
 					case "healthcheck":
@@ -616,6 +625,7 @@ export async function startServer(
 								networkBuffer: getActiveNetworkBuffer(session),
 							},
 							sessionContext,
+							configCtx,
 						);
 					case "wipe":
 						return handleWipe({
@@ -710,6 +720,7 @@ export async function startServer(
 							sessionContext,
 							context,
 							stealthOpts,
+							configCtx,
 						);
 					case "assert-ai":
 						return handleAssertAi(page, request.args);
@@ -904,12 +915,13 @@ export async function startDaemon(
 	// Load config: explicit path > upward search > global fallback
 	const resolvedConfigPath = resolveConfigPath(options.configPath);
 	let config: BrowseConfig | null = null;
+	let configError: string | null = null;
 	if (resolvedConfigPath) {
-		const { config: loaded, error: configError } =
-			loadConfig(resolvedConfigPath);
+		const { config: loaded, error: loadError } = loadConfig(resolvedConfigPath);
 		config = loaded;
-		if (configError) {
-			console.error(`Warning: ${configError}`);
+		configError = loadError;
+		if (loadError) {
+			console.error(`Warning: ${loadError}`);
 		}
 	}
 
@@ -923,6 +935,7 @@ export async function startDaemon(
 			page,
 			context,
 			config,
+			configError,
 			stealthOpts: { userAgent, navigatorPlatform, chromeMajor },
 			token,
 			tcpListen: options.tcpListen,

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -846,6 +846,30 @@ describe("daemon server", () => {
 		}
 	});
 
+	test("propagates config validation error to flow command", async () => {
+		const config = testPaths();
+		const page = mockPage();
+		const { shutdown } = await startServer(
+			mockDeps(page, {
+				configError:
+					"Invalid browse.config.json: missing 'environments' object.",
+			}),
+			config,
+			async () => {},
+		);
+
+		try {
+			const response = await sendCommand(config.socketPath, "flow", ["list"]);
+			expect(response.ok).toBe(false);
+			if (!response.ok) {
+				expect(response.error).toContain("Invalid browse.config.json");
+				expect(response.error).not.toContain("No browse.config.json found");
+			}
+		} finally {
+			await shutdown();
+		}
+	});
+
 	test("handles assert command with missing args", async () => {
 		const config = testPaths();
 		const page = mockPage();

--- a/test/flow.test.ts
+++ b/test/flow.test.ts
@@ -60,6 +60,18 @@ describe("handleFlow — flow list", () => {
 			expect(result.error).toContain("browse.config.json");
 		}
 	});
+
+	test("returns validation error when config is invalid", async () => {
+		const result = await handleFlow(null, null as any, ["list"], undefined, {
+			configError: "Invalid browse.config.json: missing 'environments' object.",
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("Invalid browse.config.json");
+			expect(result.error).toContain("missing 'environments' object");
+			expect(result.error).not.toContain("No browse.config.json found");
+		}
+	});
 });
 
 describe("handleFlow — missing flow", () => {

--- a/test/healthcheck.test.ts
+++ b/test/healthcheck.test.ts
@@ -62,6 +62,26 @@ describe("handleHealthcheck — validation", () => {
 		}
 	});
 
+	test("returns validation error when config is invalid", async () => {
+		const result = await handleHealthcheck(
+			null,
+			null as any,
+			[],
+			null as any,
+			undefined,
+			{
+				configError:
+					"Invalid browse.config.json: 'healthcheck' must be an object.",
+			},
+		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("Invalid browse.config.json");
+			expect(result.error).toContain("'healthcheck' must be an object");
+			expect(result.error).not.toContain("No browse.config.json found");
+		}
+	});
+
 	test("returns error when no healthcheck config", async () => {
 		const configNoHc: BrowseConfig = {
 			environments: BASE_CONFIG.environments,

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -67,6 +67,19 @@ describe("login command", () => {
 		}
 	});
 
+	test("returns validation error when config is invalid", async () => {
+		const res = await handleLogin(null, mockPage(), ["--env", "staging"], {
+			configError:
+				"Invalid browse.config.json: environment 'staging' is missing 'loginUrl'.",
+		});
+		expect(res.ok).toBe(false);
+		if (!res.ok) {
+			expect(res.error).toContain("Invalid browse.config.json");
+			expect(res.error).toContain("missing 'loginUrl'");
+			expect(res.error).not.toContain("No browse.config.json found");
+		}
+	});
+
 	test("returns error when --env flag is missing", async () => {
 		const res = await handleLogin(VALID_CONFIG, mockPage(), []);
 		expect(res.ok).toBe(false);


### PR DESCRIPTION
## Summary

- When `browse.config.json` exists but fails validation, commands now report the actual validation error (e.g. `Invalid browse.config.json: missing 'environments' object.`) instead of the misleading `No browse.config.json found` message
- Adds `ConfigContext` type to propagate `configError` from daemon startup through to the `flow`, `login`, `healthcheck`, and `test-matrix` command handlers
- When no config file exists at all, the original "not found" messages are preserved

Closes #55

## Test plan

- [x] Unit tests: 4 new tests across `flow.test.ts`, `login.test.ts`, `healthcheck.test.ts`, and `daemon.test.ts` verifying validation errors are reported correctly
- [x] Full test suite passes (96 tests across affected files, 0 failures)
- [x] Binary built via `./setup.sh` and tested end-to-end:
  - Invalid config (missing environments) → `Invalid browse.config.json: missing 'environments' object.`
  - Invalid config (bad flow step) → `Invalid browse.config.json: flow 'bad' step 1 has invalid type...`
  - No config at all → `No browse.config.json found. Create one with flow definitions.`