### PR TITLE
fix: detect navigation after press command

### DIFF
--- a/src/commands/press.ts
+++ b/src/commands/press.ts
@@ -1,11 +1,15 @@
 import type { Page } from "playwright";
 import type { Response } from "../protocol.ts";
+import { handleSnapshot } from "./snapshot.ts";
 
 export async function handlePress(
 	page: Page,
 	args: string[],
+	options?: { autoSnapshot?: boolean },
 ): Promise<Response> {
-	if (args.length === 0) {
+	const keys = args.filter((a) => !a.startsWith("--"));
+
+	if (keys.length === 0) {
 		return {
 			ok: false,
 			error:
@@ -14,12 +18,35 @@ export async function handlePress(
 	}
 
 	try {
-		for (const key of args) {
+		const urlBefore = page.url();
+
+		for (const key of keys) {
 			await page.keyboard.press(key);
 		}
 
-		const label = args.length === 1 ? args[0] : args.join(", ");
-		return { ok: true, data: `Pressed ${label}` };
+		const label = keys.length === 1 ? keys[0] : keys.join(", ");
+		let result = `Pressed ${label}`;
+
+		// Detect if the key press triggered navigation (e.g. Enter on a form).
+		// waitForURL is set up after the action but checks the current URL first,
+		// catching both completed and in-progress navigations.
+		const didNavigate = await page
+			.waitForURL((url) => url.href !== urlBefore, { timeout: 1_000 })
+			.then(() => true)
+			.catch(() => false);
+
+		if (didNavigate) {
+			result += `\nNavigated to: ${page.url()}`;
+
+			if (options?.autoSnapshot) {
+				const snapshotResult = await handleSnapshot(page, []);
+				if (snapshotResult.ok) {
+					return { ok: true, data: `${result}\n\n${snapshotResult.data}` };
+				}
+			}
+		}
+
+		return { ok: true, data: result };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		return { ok: false, error: message };

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -117,7 +117,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 	benchmark: ["--iterations"],
 	viewport: ["--device", "--preset"],
 	scroll: [],
-	press: [],
+	press: ["--auto-snapshot"],
 	wait: [],
 	url: [],
 	back: [],
@@ -574,7 +574,9 @@ export async function startServer(
 					case "scroll":
 						return handleScroll(page, request.args);
 					case "press":
-						return handlePress(page, request.args);
+						return handlePress(page, request.args, {
+							autoSnapshot: request.args.includes("--auto-snapshot"),
+						});
 					case "screenshot":
 						return handleScreenshot(page, request.args);
 					case "console":

--- a/test/interactions.test.ts
+++ b/test/interactions.test.ts
@@ -20,6 +20,10 @@ function mockPage() {
 		keyboard: {
 			press: mock((_key: string) => Promise.resolve()),
 		},
+		url: mock(() => "https://example.com"),
+		waitForURL: mock(async () => {
+			throw new Error("timeout");
+		}),
 		getByRole: mock((_role: string, _opts?: Record<string, unknown>) => ({
 			nth: mock((_n: number) => ({
 				click: mock(() => Promise.resolve()),
@@ -463,6 +467,39 @@ describe("handlePress", () => {
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
 			expect(result.error).toContain("Unknown key");
+		}
+	});
+
+	test("detects navigation after key press and includes warning", async () => {
+		let currentUrl = "https://example.com/form";
+		const page = {
+			...mockPage(),
+			url: mock(() => currentUrl),
+			waitForURL: mock(async () => {
+				// Simulate navigation completing during waitForURL
+				currentUrl = "https://example.com/submitted";
+			}),
+		} as never;
+
+		const result = await handlePress(page, ["Enter"]);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toContain("Pressed Enter");
+			expect(result.data).toContain("Navigated to:");
+			expect(result.data).toContain("https://example.com/submitted");
+		}
+	});
+
+	test("does not report navigation when URL is unchanged", async () => {
+		const page = mockPage();
+
+		const result = await handlePress(page, ["Tab"]);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toBe("Pressed Tab");
+			expect(result.data).not.toContain("Navigated");
 		}
 	});
 });


### PR DESCRIPTION
## Summary
- `press` now detects when a key press triggers page navigation (e.g. Enter on a form) and includes a `Navigated to: <url>` warning in the response
- Adds `--auto-snapshot` flag support to automatically re-snapshot refs after navigation
- Filters flag args from key list so `--auto-snapshot` isn't passed to `keyboard.press()`

## Test plan
- [x] Unit tests: navigation detection test, no-false-positive test (34 tests pass)
- [x] E2E: `browse press Enter` on a form → reports "Navigated to: https://example.com/?"
- [x] E2E: `browse press --auto-snapshot Enter` → reports navigation + fresh snapshot
- [x] E2E: `browse press Tab` → no navigation warning, no false positive

Closes #56