### PR TITLE
fix: exit 0 when showing help for no-args invocation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,14 +22,20 @@ export type ParsedArgs =
 			json?: boolean;
 			config?: string;
 	  }
-	| { daemon: true; config?: string; listen?: string }
-	| null;
+	| { daemon: true; config?: string; listen?: string };
 
 /**
  * Parse CLI arguments, extracting global flags (--timeout, --session, --json) from args.
  */
 export function parseArgs(argv: string[]): ParsedArgs {
-	if (argv.length === 0) return null;
+	if (argv.length === 0)
+		return {
+			cmd: "help",
+			args: [],
+			timeout: undefined,
+			session: undefined,
+			json: false,
+		};
 
 	// Extract --config from anywhere in argv (it's a global flag)
 	let config: string | undefined;
@@ -43,7 +49,15 @@ export function parseArgs(argv: string[]): ParsedArgs {
 		}
 	}
 
-	if (filteredArgv.length === 0) return null;
+	if (filteredArgv.length === 0)
+		return {
+			cmd: "help",
+			args: [],
+			timeout: undefined,
+			session: undefined,
+			json: false,
+			config,
+		};
 
 	// Extract --listen for daemon mode
 	let listen: string | undefined;
@@ -85,7 +99,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
 		}
 	}
 
-	if (remaining.length === 0) return null;
+	if (remaining.length === 0)
+		return { cmd: "help", args: [], timeout, session, json, config };
 
 	const [cmd, ...args] = remaining;
 
@@ -187,11 +202,6 @@ async function spawnDaemon(configPath?: string): Promise<void> {
 async function runCli(): Promise<void> {
 	const rawArgs = process.argv.slice(2);
 	const parsed = parseArgs(rawArgs);
-
-	if (parsed === null) {
-		process.stderr.write(`${formatOverview()}\n`);
-		process.exit(1);
-	}
 
 	if ("daemon" in parsed) {
 		await startDaemon({

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -35,9 +35,15 @@ describe("parseArgs", () => {
 		});
 	});
 
-	test("returns null for empty args", () => {
+	test("returns help command for empty args", () => {
 		const result = parseArgs([]);
-		expect(result).toBeNull();
+		expect(result).toEqual({
+			cmd: "help",
+			args: [],
+			timeout: undefined,
+			session: undefined,
+			json: false,
+		});
 	});
 
 	test("detects --daemon flag", () => {


### PR DESCRIPTION
## Summary
- Running `browse` with no arguments now exits with code 0 instead of 1
- `parseArgs` returns a `help` command instead of `null` for empty args, so the existing help handler writes to stdout and exits cleanly
- Removes the `| null` from `ParsedArgs` type and the dead null-check in `runCli`

Closes #57

## Test plan
- [x] Unit test updated: `parseArgs([])` now returns `{ cmd: "help", ... }` instead of `null`
- [x] Full unit test suite passes (`bun test test/cli.test.ts test/help.test.ts test/flags.test.ts`)
- [x] Binary built via `./setup.sh`
- [x] E2E verified: `browse` exits 0, output goes to stdout
- [x] `browse help`, `browse --help`, `browse -h` all still exit 0