### PR TITLE
fix: register help command in COMMANDS map

### DIFF
--- a/src/help.ts
+++ b/src/help.ts
@@ -295,6 +295,13 @@ Examples:
   browse a11y --standard wcag21aa    WCAG 2.1 AA
   browse a11y --json                 Machine-readable output`,
 	},
+	help: {
+		summary: "Show help for a command",
+		usage: `browse help [command]
+
+Without arguments, shows an overview of all commands.
+With a command name, shows detailed usage for that command.`,
+	},
 	quit: {
 		summary: "Shut down the daemon",
 		usage: "browse quit",

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -30,6 +30,7 @@ describe("COMMANDS registry", () => {
 			"benchmark",
 			"viewport",
 			"quit",
+			"help",
 		];
 		for (const cmd of expected) {
 			expect(COMMANDS).toHaveProperty(cmd);
@@ -77,5 +78,11 @@ describe("formatCommandHelp", () => {
 	test("includes the command usage block", () => {
 		const help = formatCommandHelp("tab");
 		expect(help).toContain(COMMANDS.tab.usage);
+	});
+
+	test("returns help text for the help command itself", () => {
+		const help = formatCommandHelp("help");
+		expect(help).not.toBeNull();
+		expect(help).toContain("help");
 	});
 });


### PR DESCRIPTION
## Summary
- Register `help` in the `COMMANDS` map in `help.ts` so `browse help help` returns proper help text instead of "Unknown command: help"
- Add test coverage for `formatCommandHelp("help")` and include `help` in the expected commands list

## Test plan
- [x] Unit tests: `formatCommandHelp("help")` returns non-null help text
- [x] Unit tests: `COMMANDS` registry includes `help`
- [x] End-to-end: built binary, `dist/browse help help` shows help text
- [x] Regression: `dist/browse help` overview still works and lists the `help` command

Closes #58