### PR TITLE
fix: show '(none)' in empty available list

### DIFF
--- a/src/commands/assert.ts
+++ b/src/commands/assert.ts
@@ -285,7 +285,8 @@ export async function handleAssert(
 
 		const permConfig = config.permissions[parsed.permission.name];
 		if (!permConfig) {
-			const available = Object.keys(config.permissions).join(", ");
+			const keys = Object.keys(config.permissions);
+			const available = keys.length > 0 ? keys.join(", ") : "(none)";
 			return {
 				ok: false,
 				error: `Unknown permission: '${parsed.permission.name}'. Available: ${available}.`,

--- a/src/commands/flow.ts
+++ b/src/commands/flow.ts
@@ -68,7 +68,8 @@ export async function handleFlow(
 	const flows = config.flows ?? {};
 
 	if (!(flowName in flows)) {
-		const available = Object.keys(flows).join(", ");
+		const keys = Object.keys(flows);
+		const available = keys.length > 0 ? keys.join(", ") : "(none)";
 		return {
 			ok: false,
 			error: `Unknown flow: '${flowName}'. Available: ${available}.`,

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -44,7 +44,8 @@ export async function handleLogin(
 
 	const envConfig = config.environments[envName];
 	if (!envConfig) {
-		const available = Object.keys(config.environments).join(", ");
+		const keys = Object.keys(config.environments);
+		const available = keys.length > 0 ? keys.join(", ") : "(none)";
 		return {
 			ok: false,
 			error: `Unknown environment: '${envName}'. Available: ${available}.`,

--- a/src/commands/test-matrix.ts
+++ b/src/commands/test-matrix.ts
@@ -96,7 +96,8 @@ export async function handleTestMatrix(
 	// Validate flow exists
 	const flows = config.flows ?? {};
 	if (!(flowName in flows)) {
-		const available = Object.keys(flows).join(", ");
+		const keys = Object.keys(flows);
+		const available = keys.length > 0 ? keys.join(", ") : "(none)";
 		return {
 			ok: false,
 			error: `Unknown flow: '${flowName}'. Available: ${available}.`,

--- a/test/assert.test.ts
+++ b/test/assert.test.ts
@@ -519,6 +519,24 @@ describe("handleAssert", () => {
 		}
 	});
 
+	test("shows '(none)' when permissions object is empty", async () => {
+		const page = createMockPage({});
+		const configEmptyPerms: BrowseConfig = {
+			environments: PERM_CONFIG.environments,
+			permissions: {},
+		};
+		const result = await handleAssert(configEmptyPerms, page, [
+			"permission",
+			"Nonexistent",
+			"granted",
+		]);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("(none)");
+			expect(result.error).not.toEndWith("Available: .");
+		}
+	});
+
 	test("permission granted assertion passes", async () => {
 		const page = createMockPage({
 			visibleSelectors: new Set([".admin-panel"]),

--- a/test/flow.test.ts
+++ b/test/flow.test.ts
@@ -84,6 +84,21 @@ describe("handleFlow — missing flow", () => {
 			expect(result.error).toContain("simple");
 		}
 	});
+
+	test("shows '(none)' when no flows are configured", async () => {
+		const configNoFlows: BrowseConfig = {
+			environments: BASE_CONFIG.environments,
+			flows: {},
+		};
+		const result = await handleFlow(configNoFlows, null as any, [
+			"nonexistent",
+		]);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("(none)");
+			expect(result.error).not.toEndWith("Available: .");
+		}
+	});
 });
 
 describe("handleFlow — missing variables", () => {

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -106,6 +106,19 @@ describe("login command", () => {
 		}
 	});
 
+	test("shows '(none)' when no environments are configured", async () => {
+		const emptyConfig: BrowseConfig = { environments: {} };
+		const res = await handleLogin(emptyConfig, mockPage(), [
+			"--env",
+			"nonexistent",
+		]);
+		expect(res.ok).toBe(false);
+		if (!res.ok) {
+			expect(res.error).toContain("(none)");
+			expect(res.error).not.toEndWith("Available: .");
+		}
+	});
+
 	test("returns error when credentials env vars are missing", async () => {
 		delete process.env.BROWSE_STAGING_USER;
 		delete process.env.BROWSE_STAGING_PASS;


### PR DESCRIPTION
## Summary
- When no environments, flows, or permissions are configured, error messages showed "Available: ." (empty join followed by period)
- Now displays "Available: (none)." instead
- Fixed in `login`, `flow`, `assert`, and `test-matrix` commands (`diff` and `flow-share` already handled this correctly)

Fixes #59

## Test plan
- [x] Unit tests added for empty list case in `login.test.ts`, `flow.test.ts`, `assert.test.ts`
- [x] Full test suite passes (76 tests across affected files, all green)
- [x] Binary built and end-to-end verified: `browse login --env nonexistent` → `Available: (none).`