### PR TITLE
feat: add --dry-run flag to screenshots clean

### DIFF
--- a/src/commands/screenshots.ts
+++ b/src/commands/screenshots.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { extname, join } from "node:path";
 import type { Response } from "../protocol.ts";
 
-const SCREENSHOTS_DIR = join(homedir(), ".bun-browse", "screenshots");
+const DEFAULT_SCREENSHOTS_DIR = join(homedir(), ".bun-browse", "screenshots");
 const ALLOWED_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp"]);
 
 function isScreenshotFile(filepath: string): boolean {
@@ -42,17 +42,17 @@ function formatBytes(bytes: number): string {
 	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function listScreenshots(): Response {
-	if (!existsSync(SCREENSHOTS_DIR)) {
+function listScreenshots(dir: string): Response {
+	if (!existsSync(dir)) {
 		return { ok: true, data: "No screenshots directory found." };
 	}
 
-	const files = readdirSync(SCREENSHOTS_DIR);
+	const files = readdirSync(dir);
 
 	const entries = files
-		.filter((name) => isScreenshotFile(join(SCREENSHOTS_DIR, name)))
+		.filter((name) => isScreenshotFile(join(dir, name)))
 		.map((name) => {
-			const filepath = join(SCREENSHOTS_DIR, name);
+			const filepath = join(dir, name);
 			const stat = statSync(filepath);
 			return { name, size: stat.size, mtime: stat.mtimeMs };
 		});
@@ -74,12 +74,13 @@ function listScreenshots(): Response {
 	return { ok: true, data: lines.join("\n") };
 }
 
-function cleanScreenshots(args: string[]): Response {
-	if (!existsSync(SCREENSHOTS_DIR)) {
+function cleanScreenshots(args: string[], dir: string): Response {
+	if (!existsSync(dir)) {
 		return { ok: true, data: "No screenshots directory found." };
 	}
 
 	const olderThanIdx = args.indexOf("--older-than");
+	const dryRun = args.includes("--dry-run");
 	let cutoffMs: number | null = null;
 
 	if (olderThanIdx !== -1) {
@@ -97,37 +98,51 @@ function cleanScreenshots(args: string[]): Response {
 		cutoffMs = Date.now() - duration;
 	}
 
-	const files = readdirSync(SCREENSHOTS_DIR);
-	let deleted = 0;
+	const files = readdirSync(dir);
+	const matched: { name: string; size: number }[] = [];
 
 	for (const name of files) {
-		const filepath = join(SCREENSHOTS_DIR, name);
+		const filepath = join(dir, name);
 		if (!isScreenshotFile(filepath)) continue;
 		const stat = statSync(filepath);
 
 		if (cutoffMs === null || stat.mtimeMs < cutoffMs) {
-			unlinkSync(filepath);
-			deleted++;
+			if (dryRun) {
+				matched.push({ name, size: stat.size });
+			} else {
+				unlinkSync(filepath);
+				matched.push({ name, size: stat.size });
+			}
 		}
+	}
+
+	if (dryRun) {
+		const totalSize = matched.reduce((sum, f) => sum + f.size, 0);
+		const listing = matched.map((f) => `  ${f.name}  ${formatBytes(f.size)}`);
+		const summary = `Would delete ${matched.length} screenshot${matched.length === 1 ? "" : "s"} (${formatBytes(totalSize)}).`;
+		if (listing.length > 0) {
+			return { ok: true, data: `${summary}\n${listing.join("\n")}` };
+		}
+		return { ok: true, data: summary };
 	}
 
 	return {
 		ok: true,
-		data: `Deleted ${deleted} screenshot${deleted === 1 ? "" : "s"}.`,
+		data: `Deleted ${matched.length} screenshot${matched.length === 1 ? "" : "s"}.`,
 	};
 }
 
-function countScreenshots(): Response {
-	if (!existsSync(SCREENSHOTS_DIR)) {
+function countScreenshots(dir: string): Response {
+	if (!existsSync(dir)) {
 		return { ok: true, data: "No screenshots directory found." };
 	}
 
-	const files = readdirSync(SCREENSHOTS_DIR);
+	const files = readdirSync(dir);
 	let totalSize = 0;
 	let count = 0;
 
 	for (const name of files) {
-		const filepath = join(SCREENSHOTS_DIR, name);
+		const filepath = join(dir, name);
 		if (!isScreenshotFile(filepath)) continue;
 		const stat = statSync(filepath);
 		totalSize += stat.size;
@@ -140,16 +155,20 @@ function countScreenshots(): Response {
 	};
 }
 
-export async function handleScreenshots(args: string[]): Promise<Response> {
+export async function handleScreenshots(
+	args: string[],
+	screenshotsDir?: string,
+): Promise<Response> {
+	const dir = screenshotsDir ?? DEFAULT_SCREENSHOTS_DIR;
 	const subcommand = args[0];
 
 	switch (subcommand) {
 		case "list":
-			return listScreenshots();
+			return listScreenshots(dir);
 		case "clean":
-			return cleanScreenshots(args.slice(1));
+			return cleanScreenshots(args.slice(1), dir);
 		case "count":
-			return countScreenshots();
+			return countScreenshots(dir);
 		default:
 			return {
 				ok: false,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -142,7 +142,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 	"element-count": [],
 	trace: ["--screenshots", "--snapshots", "--out"],
 	init: ["--force"],
-	screenshots: ["--older-than"],
+	screenshots: ["--older-than", "--dry-run"],
 	report: ["--out", "--title", "--screenshots"],
 	completions: [],
 	form: ["--data", "--auto-snapshot"],

--- a/src/help.ts
+++ b/src/help.ts
@@ -442,11 +442,12 @@ flows, and healthcheck configuration.`,
 	screenshots: {
 		summary: "Manage screenshot files",
 		usage: `browse screenshots list                    List all screenshots
-browse screenshots clean [--older-than <duration>]   Delete screenshots
+browse screenshots clean [--older-than <duration>] [--dry-run]   Delete screenshots
 browse screenshots count                  Show count and total size
 
 Flags:
-  --older-than <duration>   Only delete screenshots older than duration (e.g. 7d, 24h, 30m)`,
+  --older-than <duration>   Only delete screenshots older than duration (e.g. 7d, 24h, 30m)
+  --dry-run                 Show what would be deleted without removing files`,
 	},
 	report: {
 		summary: "Generate an HTML QA report",

--- a/test/screenshots-clean.test.ts
+++ b/test/screenshots-clean.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { handleScreenshots } from "../src/commands/screenshots.ts";
+
+const TEST_DIR = join(import.meta.dir, ".tmp-screenshots-clean");
+
+function createScreenshot(name: string, ageMs = 0): string {
+	const filepath = join(TEST_DIR, name);
+	writeFileSync(filepath, "fake-png-data");
+	if (ageMs > 0) {
+		const past = new Date(Date.now() - ageMs);
+		utimesSync(filepath, past, past);
+	}
+	return filepath;
+}
+
+beforeEach(() => {
+	mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+	rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("screenshots clean --dry-run", () => {
+	test("lists files that would be deleted without removing them", async () => {
+		createScreenshot("a.png");
+		createScreenshot("b.png");
+
+		const res = await handleScreenshots(["clean", "--dry-run"], TEST_DIR);
+
+		expect(res.ok).toBe(true);
+		if (res.ok) {
+			expect(res.data).toContain("Would delete 2 screenshot");
+		}
+		// Files must still exist
+		expect(existsSync(join(TEST_DIR, "a.png"))).toBe(true);
+		expect(existsSync(join(TEST_DIR, "b.png"))).toBe(true);
+	});
+
+	test("respects --older-than filter in dry-run mode", async () => {
+		createScreenshot("old.png", 2 * 60 * 60 * 1000); // 2 hours old
+		createScreenshot("new.png"); // just created
+
+		const res = await handleScreenshots(
+			["clean", "--older-than", "1h", "--dry-run"],
+			TEST_DIR,
+		);
+
+		expect(res.ok).toBe(true);
+		if (res.ok) {
+			expect(res.data).toContain("Would delete 1 screenshot");
+		}
+		// Both files must still exist
+		expect(existsSync(join(TEST_DIR, "old.png"))).toBe(true);
+		expect(existsSync(join(TEST_DIR, "new.png"))).toBe(true);
+	});
+
+	test("reports zero when no files match in dry-run mode", async () => {
+		createScreenshot("new.png"); // just created
+
+		const res = await handleScreenshots(
+			["clean", "--older-than", "1h", "--dry-run"],
+			TEST_DIR,
+		);
+
+		expect(res.ok).toBe(true);
+		if (res.ok) {
+			expect(res.data).toContain("Would delete 0 screenshot");
+		}
+	});
+
+	test("shows file names in dry-run output", async () => {
+		createScreenshot("shot1.png");
+
+		const res = await handleScreenshots(["clean", "--dry-run"], TEST_DIR);
+
+		expect(res.ok).toBe(true);
+		if (res.ok) {
+			expect(res.data).toContain("shot1.png");
+		}
+	});
+});
+
+describe("screenshots clean (existing behaviour with dir override)", () => {
+	test("deletes files without --dry-run", async () => {
+		createScreenshot("a.png");
+		createScreenshot("b.png");
+
+		const res = await handleScreenshots(["clean"], TEST_DIR);
+
+		expect(res.ok).toBe(true);
+		if (res.ok) {
+			expect(res.data).toContain("Deleted 2 screenshot");
+		}
+		expect(existsSync(join(TEST_DIR, "a.png"))).toBe(false);
+		expect(existsSync(join(TEST_DIR, "b.png"))).toBe(false);
+	});
+
+	test("deletes only old files with --older-than", async () => {
+		createScreenshot("old.png", 2 * 60 * 60 * 1000);
+		createScreenshot("new.png");
+
+		const res = await handleScreenshots(
+			["clean", "--older-than", "1h"],
+			TEST_DIR,
+		);
+
+		expect(res.ok).toBe(true);
+		if (res.ok) {
+			expect(res.data).toContain("Deleted 1 screenshot");
+		}
+		expect(existsSync(join(TEST_DIR, "old.png"))).toBe(false);
+		expect(existsSync(join(TEST_DIR, "new.png"))).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `--dry-run` flag to `browse screenshots clean` that lists files that would be deleted (with names and sizes) without actually removing them
- Makes the screenshots directory injectable in `handleScreenshots()` for testability
- Adds unit tests covering dry-run behaviour with and without `--older-than`

Closes #62

## Test plan

- [x] Unit tests pass (`bun test test/screenshots-clean.test.ts` — 6 tests)
- [x] Existing screenshot tests still pass
- [x] Binary built and E2E tested: `browse screenshots clean --dry-run` lists files without deleting
- [x] E2E tested: `browse screenshots clean --older-than 30d --dry-run` respects age filter
- [x] `browse help screenshots` shows the new flag