### PR TITLE
fix: replace RingBuffer Array.shift() with O(1) circular buffer

### DIFF
--- a/src/buffers.ts
+++ b/src/buffers.ts
@@ -1,29 +1,48 @@
 export class RingBuffer<T> {
-	private items: T[] = [];
+	private items: (T | undefined)[];
+	private head = 0;
+	private size = 0;
 	private capacity: number;
 
 	constructor(capacity = 500) {
 		this.capacity = capacity;
+		this.items = new Array(capacity);
 	}
 
 	push(item: T): void {
-		if (this.items.length >= this.capacity) {
-			this.items.shift();
+		const index = (this.head + this.size) % this.capacity;
+		if (this.size === this.capacity) {
+			this.head = (this.head + 1) % this.capacity;
+		} else {
+			this.size++;
 		}
-		this.items.push(item);
+		this.items[index] = item;
 	}
 
 	drain(filter?: (item: T) => boolean): T[] {
-		const result = filter ? this.items.filter(filter) : [...this.items];
-		this.items = [];
+		const result: T[] = [];
+		for (let i = 0; i < this.size; i++) {
+			const item = this.items[(this.head + i) % this.capacity] as T;
+			if (!filter || filter(item)) result.push(item);
+		}
+		this.head = 0;
+		this.size = 0;
+		this.items = new Array(this.capacity);
 		return result;
 	}
 
 	peek(filter?: (item: T) => boolean): T[] {
-		return filter ? this.items.filter(filter) : [...this.items];
+		const result: T[] = [];
+		for (let i = 0; i < this.size; i++) {
+			const item = this.items[(this.head + i) % this.capacity] as T;
+			if (!filter || filter(item)) result.push(item);
+		}
+		return result;
 	}
 
 	clear(): void {
-		this.items = [];
+		this.head = 0;
+		this.size = 0;
+		this.items = new Array(this.capacity);
 	}
 }

--- a/test/buffers.test.ts
+++ b/test/buffers.test.ts
@@ -96,4 +96,48 @@ describe("RingBuffer", () => {
 		const buf = new RingBuffer<number>(10);
 		expect(buf.peek()).toEqual([]);
 	});
+
+	test("push after drain resumes correctly", () => {
+		const buf = new RingBuffer<number>(3);
+		buf.push(1);
+		buf.push(2);
+		buf.push(3);
+		buf.drain();
+		buf.push(10);
+		buf.push(11);
+		expect(buf.peek()).toEqual([10, 11]);
+	});
+
+	test("push after clear resumes correctly", () => {
+		const buf = new RingBuffer<number>(3);
+		buf.push(1);
+		buf.push(2);
+		buf.push(3);
+		buf.push(4); // wraps
+		buf.clear();
+		buf.push(10);
+		expect(buf.peek()).toEqual([10]);
+	});
+
+	test("capacity of 1 keeps only the last item", () => {
+		const buf = new RingBuffer<number>(1);
+		buf.push(1);
+		buf.push(2);
+		buf.push(3);
+		expect(buf.peek()).toEqual([3]);
+		expect(buf.drain()).toEqual([3]);
+		expect(buf.peek()).toEqual([]);
+	});
+
+	test("drain with filter after wrap returns correct items", () => {
+		const buf = new RingBuffer<number>(3);
+		buf.push(1);
+		buf.push(2);
+		buf.push(3);
+		buf.push(4); // evicts 1, buffer: [2, 3, 4]
+		buf.push(5); // evicts 2, buffer: [3, 4, 5]
+		const odds = buf.drain((n) => n % 2 !== 0);
+		expect(odds).toEqual([3, 5]);
+		expect(buf.peek()).toEqual([]);
+	});
 });


### PR DESCRIPTION
## Summary

- Replaces the `Array.shift()`-based eviction in `RingBuffer` with a proper circular buffer using head/size index tracking
- Push at capacity is now O(1) instead of O(n) — no element shifting, single pre-allocated backing array
- API surface (`push`, `drain`, `peek`, `clear`) is unchanged

## Test plan

- [x] All 15 existing `RingBuffer` tests pass unchanged
- [x] Added 4 new edge-case tests: push-after-drain, push-after-clear, capacity-of-1, filter-after-wrap
- [x] Lint passes (`bun run check:fix`)

Closes #88