### PR TITLE
feat: add trace view and trace list commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ browse scroll @e3                   # scroll element into view
 browse screenshot                   # capture the page
 browse trace start                  # start recording a Playwright trace
 browse trace stop --out trace.zip   # stop and save the trace
+browse trace view --latest          # open most recent trace in viewer
 browse init                         # generate a browse.config.json template
 browse screenshots list             # list saved screenshots
 browse report --out report.html     # generate an HTML report from screenshots
@@ -433,7 +434,7 @@ Measured with `browse benchmark`:
 | `element-count <selector>` | Count elements matching a selector |
 | `wipe` | Clear all session data |
 | `benchmark` | Measure latency |
-| `trace start\|stop\|status` | Record Playwright traces (`--screenshots`, `--snapshots`, `--out`) |
+| `trace start\|stop\|view\|list\|status` | Record and view Playwright traces (`--screenshots`, `--snapshots`, `--out`, `--latest`, `--port`) |
 | `report --out <path>` | Generate HTML report from screenshots (`--title`, `--screenshots`) |
 | `init` | Generate a `browse.config.json` template (`--force` to overwrite) |
 | `form --data <json>` | Bulk-fill form fields (`--auto-snapshot`) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -66,7 +66,7 @@ For configured applications, `browse healthcheck` gives a quick pass/fail across
 | **Accessibility** | `a11y` (full page), `a11y @eN` (element), `a11y --standard wcag2aa`, `a11y --json` |
 | **Flows** | `flow list`, `flow <name> --var key=value` (`--reporter junit`, `--dry-run`, `--stream`), `healthcheck` (`--reporter junit`, `--parallel`, `--concurrency`), `test-matrix --roles r1,r2 --flow <name>`, `diff --baseline <url> --current <url>` |
 | **Sessions** | `session list/create/close`, `--session <name>` on any command |
-| **Tracing** | `trace start` (`--screenshots`, `--snapshots`), `trace stop --out <path>`, `trace status` |
+| **Tracing** | `trace start` (`--screenshots`, `--snapshots`), `trace stop --out <path>`, `trace view [<path>] --latest --port <n>`, `trace list`, `trace status` |
 | **Tooling** | `init`, `report --out <path>`, `replay --out <path>`, `flow-share export/import/list/install/publish`, `screenshots list/clean/count`, `completions bash/zsh/fish`, `status --json` |
 
 Run `browse help <command>` for flags and detailed usage — don't guess at flags.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1137,7 +1137,7 @@ Shut down the daemon.
 browse trace start [--screenshots] [--snapshots]
 ```
 
-Start recording a Playwright trace. While recording, all page actions are captured for later analysis in the [Playwright Trace Viewer](https://trace.playwright.dev).
+Start recording a Playwright trace. While recording, all page actions are captured for later analysis in the Playwright Trace Viewer.
 
 | Flag | Description |
 |------|-------------|
@@ -1161,13 +1161,48 @@ Stop recording and save the trace to a file.
 
 | Flag | Description |
 |------|-------------|
-| `--out <path>` | Output path for the trace file (default: `trace.zip`) |
+| `--out <path>` | Output path for the trace file (default: `~/.bun-browse/traces/`) |
 
 **Examples:**
 
 ```bash
 browse trace stop
 browse trace stop --out /tmp/my-trace.zip
+```
+
+### trace view
+
+```
+browse trace view [<path>] [--latest] [--port <port>]
+```
+
+Open a trace file in the Playwright Trace Viewer. Launches the viewer as a background process.
+
+| Flag | Description |
+|------|-------------|
+| `--latest` | View the most recently saved trace |
+| `--port <port>` | Serve the trace viewer on a specific port |
+
+**Examples:**
+
+```bash
+browse trace view /tmp/my-trace.zip
+browse trace view --latest
+browse trace view --latest --port 9300
+```
+
+### trace list
+
+```
+browse trace list
+```
+
+List all saved trace files in `~/.bun-browse/traces/`, sorted newest-first. Shows filename, size, and date.
+
+**Examples:**
+
+```bash
+browse trace list
 ```
 
 ### trace status

--- a/src/commands/trace.ts
+++ b/src/commands/trace.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import type { BrowserContext } from "playwright";
 import type { Response } from "../protocol.ts";
 
@@ -13,9 +13,10 @@ export function createTraceState(): TraceState {
 	return { recording: false };
 }
 
+const TRACES_DIR = join(homedir(), ".bun-browse", "traces");
+
 function generateDefaultTracePath(): string {
-	const dir = join(homedir(), ".bun-browse", "traces");
-	mkdirSync(dir, { recursive: true });
+	mkdirSync(TRACES_DIR, { recursive: true });
 
 	const now = new Date();
 	const pad = (n: number, len = 2) => String(n).padStart(len, "0");
@@ -29,19 +30,70 @@ function generateDefaultTracePath(): string {
 		pad(now.getSeconds()),
 	].join("");
 
-	return join(dir, `trace-${timestamp}.zip`);
+	return join(TRACES_DIR, `trace-${timestamp}.zip`);
+}
+
+/** List trace .zip files sorted newest-first. */
+export function listTraceFiles(): {
+	name: string;
+	path: string;
+	mtime: Date;
+	sizeBytes: number;
+}[] {
+	if (!existsSync(TRACES_DIR)) return [];
+
+	return readdirSync(TRACES_DIR)
+		.filter((f) => f.endsWith(".zip"))
+		.map((f) => {
+			const fullPath = join(TRACES_DIR, f);
+			const st = statSync(fullPath);
+			return { name: f, path: fullPath, mtime: st.mtime, sizeBytes: st.size };
+		})
+		.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+}
+
+function formatSize(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function findPlaywrightCli(): string {
+	// Resolve the playwright CLI binary from node_modules
+	const localBin = join(process.cwd(), "node_modules", ".bin", "playwright");
+	if (existsSync(localBin)) return localBin;
+	// Fallback to npx
+	return "npx";
+}
+
+export type SpawnFn = (
+	cmd: string,
+	args: string[],
+) => { pid: number | undefined };
+
+/** Default spawn that launches a detached process. */
+function defaultSpawn(
+	cmd: string,
+	args: string[],
+): { pid: number | undefined } {
+	const proc = Bun.spawn([cmd, ...args], {
+		stdio: ["ignore", "ignore", "ignore"],
+	});
+	proc.unref();
+	return { pid: proc.pid };
 }
 
 export async function handleTrace(
 	context: BrowserContext,
 	traceState: TraceState,
 	args: string[],
+	deps?: { spawn?: SpawnFn },
 ): Promise<Response> {
 	if (args.length === 0) {
 		return {
 			ok: false,
 			error:
-				"Usage: browse trace start [--screenshots] [--snapshots]\n       browse trace stop [--out <path>]\n       browse trace status",
+				"Usage: browse trace start [--screenshots] [--snapshots]\n       browse trace stop [--out <path>]\n       browse trace view [<path>] [--latest] [--port <port>]\n       browse trace list\n       browse trace status",
 		};
 	}
 
@@ -149,7 +201,7 @@ export async function handleTrace(
 
 			return {
 				ok: true,
-				data: `Trace saved to ${savePath} (${elapsed}s recording)\nView with: npx playwright show-trace ${savePath}`,
+				data: `Trace saved to ${savePath} (${elapsed}s recording)\nView with: browse trace view ${savePath}`,
 			};
 		} catch (err) {
 			// tracing.stop failed — the browser may still be recording,
@@ -162,8 +214,113 @@ export async function handleTrace(
 		}
 	}
 
+	if (subcommand === "list") {
+		const traces = listTraceFiles();
+		if (traces.length === 0) {
+			return { ok: true, data: "No traces found." };
+		}
+
+		const lines = traces.map(
+			(t) =>
+				`${t.name}  ${formatSize(t.sizeBytes)}  ${t.mtime.toISOString().replace("T", " ").slice(0, 19)}`,
+		);
+		return {
+			ok: true,
+			data: `${traces.length} trace(s):\n${lines.join("\n")}`,
+		};
+	}
+
+	if (subcommand === "view") {
+		const useLatest = args.includes("--latest");
+
+		// Parse --port flag
+		let port: string | undefined;
+		for (let i = 1; i < args.length; i++) {
+			if (args[i] === "--port" && i + 1 < args.length) {
+				port = args[i + 1];
+				break;
+			}
+		}
+
+		// Determine trace file path
+		let tracePath: string | undefined;
+
+		if (useLatest) {
+			const traces = listTraceFiles();
+			if (traces.length === 0) {
+				return {
+					ok: false,
+					error:
+						"No traces found. Record one with 'browse trace start' then 'browse trace stop'.",
+				};
+			}
+			tracePath = traces[0]?.path;
+		} else {
+			// Find positional path argument (first arg after "view" that isn't a flag)
+			for (let i = 1; i < args.length; i++) {
+				const arg = args[i] as string;
+				if (arg === "--port") {
+					i++; // skip value
+					continue;
+				}
+				if (arg.startsWith("--")) continue;
+				tracePath = arg;
+				break;
+			}
+		}
+
+		if (!tracePath) {
+			return {
+				ok: false,
+				error:
+					"Provide a trace file path or use --latest.\nUsage: browse trace view <path>\n       browse trace view --latest",
+			};
+		}
+
+		// Resolve relative paths
+		tracePath = resolve(tracePath);
+
+		if (!existsSync(tracePath)) {
+			return {
+				ok: false,
+				error: `Trace file not found: ${tracePath}`,
+			};
+		}
+
+		// Build playwright show-trace command
+		const playwrightCli = findPlaywrightCli();
+		const showTraceArgs: string[] =
+			playwrightCli === "npx" ? ["playwright", "show-trace"] : ["show-trace"];
+
+		if (port) {
+			showTraceArgs.push("--port", port);
+		}
+		showTraceArgs.push(tracePath);
+
+		const spawn = deps?.spawn ?? defaultSpawn;
+
+		try {
+			const { pid } = spawn(playwrightCli, showTraceArgs);
+
+			const parts = [`Trace viewer opened for ${basename(tracePath)}`];
+			if (port) {
+				parts.push(`Serving on port ${port}`);
+			}
+			if (pid) {
+				parts.push(`(PID: ${pid})`);
+			}
+			return { ok: true, data: parts.join("\n") };
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			return {
+				ok: false,
+				error: `Failed to launch trace viewer: ${message}`,
+			};
+		}
+	}
+
 	return {
 		ok: false,
-		error: `Unknown trace subcommand: '${subcommand}'. Use start, stop, or status.`,
+		error: `Unknown trace subcommand: '${subcommand}'. Use start, stop, view, list, or status.`,
 	};
 }

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -122,7 +122,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 	title: [],
 	pdf: [],
 	"element-count": [],
-	trace: ["--screenshots", "--snapshots", "--out"],
+	trace: ["--screenshots", "--snapshots", "--out", "--port", "--latest"],
 	report: ["--out", "--title", "--screenshots"],
 	init: ["--force"],
 	screenshots: ["--older-than"],

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -145,7 +145,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 	title: [],
 	pdf: [],
 	"element-count": [],
-	trace: ["--screenshots", "--snapshots", "--out"],
+	trace: ["--screenshots", "--snapshots", "--out", "--port", "--latest"],
 	init: ["--force"],
 	screenshots: ["--older-than", "--dry-run"],
 	report: ["--out", "--title", "--screenshots"],

--- a/src/help.ts
+++ b/src/help.ts
@@ -424,17 +424,19 @@ If no path given, saves to ~/.bun-browse/exports/ with a timestamp.`,
 Returns the number of elements matching the selector.`,
 	},
 	trace: {
-		summary: "Record and save Playwright traces",
+		summary: "Record, view, and manage Playwright traces",
 		usage: `browse trace start [--screenshots] [--snapshots]   Start recording
 browse trace stop [--out <path>]                   Stop and save trace
+browse trace view [<path>] [--latest] [--port <n>] Open trace in viewer
+browse trace list                                  List saved traces
 browse trace status                                Check recording status
 
 Flags:
   --screenshots   Capture screenshots during recording
   --snapshots     Capture DOM snapshots during recording
   --out <path>    Output path for trace file (default: ~/.bun-browse/traces/)
-
-View traces with: npx playwright show-trace <trace.zip>`,
+  --latest        View the most recent trace
+  --port <n>      Serve trace viewer on a specific port`,
 	},
 	init: {
 		summary: "Generate a browse.config.json template",

--- a/test/unit/trace.test.ts
+++ b/test/unit/trace.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, mock, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	createTraceState,
+	handleTrace,
+	listTraceFiles,
+	type SpawnFn,
+} from "../../src/commands/trace.ts";
+
+// Stub BrowserContext with just enough for trace tests
+function mockContext(opts?: {
+	startFail?: boolean;
+	stopFail?: boolean;
+	stopNoFile?: boolean;
+}) {
+	return {
+		tracing: {
+			start: opts?.startFail
+				? mock(() => Promise.reject(new Error("start failed")))
+				: mock(() => Promise.resolve()),
+			stop: opts?.stopFail
+				? mock(() => Promise.reject(new Error("stop failed")))
+				: mock(({ path }: { path: string }) => {
+						if (!opts?.stopNoFile) {
+							mkdirSync(join(path, ".."), { recursive: true });
+							writeFileSync(path, "fake-trace");
+						}
+						return Promise.resolve();
+					}),
+		},
+	} as never;
+}
+
+function noopSpawn(): SpawnFn {
+	return mock((_cmd: string, _args: string[]) => ({ pid: 12345 }));
+}
+
+describe("trace subcommand routing", () => {
+	test("returns usage when no args", async () => {
+		const result = await handleTrace(mockContext(), createTraceState(), []);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("Usage:");
+			expect(result.error).toContain("trace view");
+		}
+	});
+
+	test("returns error for unknown subcommand", async () => {
+		const result = await handleTrace(mockContext(), createTraceState(), [
+			"foobar",
+		]);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("Unknown trace subcommand");
+			expect(result.error).toContain("view");
+			expect(result.error).toContain("list");
+		}
+	});
+});
+
+describe("trace list", () => {
+	test("returns message when no traces exist", async () => {
+		const result = await handleTrace(mockContext(), createTraceState(), [
+			"list",
+		]);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			// Either "No traces found" or lists traces from user's machine
+			expect(typeof result.data).toBe("string");
+		}
+	});
+});
+
+describe("trace view", () => {
+	test("returns error when no path and no --latest", async () => {
+		const result = await handleTrace(mockContext(), createTraceState(), [
+			"view",
+		]);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("Provide a trace file path");
+		}
+	});
+
+	test("returns error when file does not exist", async () => {
+		const result = await handleTrace(mockContext(), createTraceState(), [
+			"view",
+			"/tmp/nonexistent-trace-12345.zip",
+		]);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("Trace file not found");
+		}
+	});
+
+	test("launches viewer for existing file", async () => {
+		const tmpFile = join(tmpdir(), `test-trace-${Date.now()}.zip`);
+		writeFileSync(tmpFile, "fake-trace-data");
+
+		const spawn = noopSpawn();
+		const result = await handleTrace(
+			mockContext(),
+			createTraceState(),
+			["view", tmpFile],
+			{ spawn },
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toContain("Trace viewer opened");
+			expect(result.data).toContain("PID: 12345");
+		}
+
+		expect(spawn).toHaveBeenCalledTimes(1);
+
+		// Clean up
+		rmSync(tmpFile, { force: true });
+	});
+
+	test("passes --port to spawn args", async () => {
+		const tmpFile = join(tmpdir(), `test-trace-port-${Date.now()}.zip`);
+		writeFileSync(tmpFile, "fake-trace-data");
+
+		const spawn = noopSpawn();
+		const result = await handleTrace(
+			mockContext(),
+			createTraceState(),
+			["view", tmpFile, "--port", "9300"],
+			{ spawn },
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toContain("Serving on port 9300");
+		}
+
+		// Verify spawn was called with port args
+		const spawnArgs = (spawn as ReturnType<typeof mock>).mock.calls[0];
+		const allArgs = spawnArgs?.[1] as string[];
+		expect(allArgs).toContain("--port");
+		expect(allArgs).toContain("9300");
+
+		rmSync(tmpFile, { force: true });
+	});
+
+	test("returns error when spawn fails", async () => {
+		const tmpFile = join(tmpdir(), `test-trace-fail-${Date.now()}.zip`);
+		writeFileSync(tmpFile, "fake-trace-data");
+
+		const failSpawn: SpawnFn = () => {
+			throw new Error("spawn failed");
+		};
+
+		const result = await handleTrace(
+			mockContext(),
+			createTraceState(),
+			["view", tmpFile],
+			{ spawn: failSpawn },
+		);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("Failed to launch trace viewer");
+		}
+
+		rmSync(tmpFile, { force: true });
+	});
+});
+
+describe("trace stop output", () => {
+	test("stop message references browse trace view", async () => {
+		const tmpDir = join(tmpdir(), `browse-trace-test-${Date.now()}`);
+		mkdirSync(tmpDir, { recursive: true });
+		const outPath = join(tmpDir, "trace.zip");
+
+		const state = createTraceState();
+		state.recording = true;
+		state.startedAt = Date.now() - 5000;
+
+		const result = await handleTrace(mockContext(), state, [
+			"stop",
+			"--out",
+			outPath,
+		]);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toContain("browse trace view");
+			expect(result.data).not.toContain("npx playwright");
+		}
+
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+});
+
+describe("listTraceFiles", () => {
+	test("returns an array", () => {
+		const files = listTraceFiles();
+		expect(Array.isArray(files)).toBe(true);
+	});
+
+	test("each entry has required fields", () => {
+		const files = listTraceFiles();
+		for (const f of files) {
+			expect(typeof f.name).toBe("string");
+			expect(typeof f.path).toBe("string");
+			expect(f.mtime).toBeInstanceOf(Date);
+			expect(typeof f.sizeBytes).toBe("number");
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Closes #89

- Adds `browse trace view` command that opens a trace file in Playwright's built-in Trace Viewer, keeping the full QA workflow within the CLI
- Adds `browse trace list` command to list saved traces with file size and date
- Supports `--latest` to view the most recent trace and `--port` to serve on a specific port
- Updates `trace stop` output to reference `browse trace view` instead of `npx playwright show-trace`

## Changes

- **src/commands/trace.ts** — Added `view` and `list` subcommands with injectable spawn for testability
- **src/daemon.ts** — Added `--port` and `--latest` to trace known flags
- **src/help.ts** — Updated trace help text
- **src/completions.ts** — Updated shell completion flags
- **docs/commands.md** — Added trace view and trace list documentation
- **SKILL.md** — Updated tracing section
- **README.md** — Updated trace examples and command table
- **test/unit/trace.test.ts** — 11 unit tests covering view, list, error cases, and spawn injection

## Test plan

- [x] All 821 existing tests pass
- [x] 11 new trace unit tests pass
- [x] Lint clean (`bun run check:fix`)
- [ ] Manual: `browse trace start && browse trace stop && browse trace view --latest`
- [ ] Manual: `browse trace list` shows saved traces