### PR TITLE
feat: add --watch, --interval, and --exit-code flags to status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ browse pdf ./report.pdf                     # export to specific path
 browse ping                                 # check if daemon is alive
 browse status                               # show URL, sessions, uptime
 browse status --json                        # machine-readable daemon status
+browse status --watch                       # live-updating status (every 5s)
+browse status --watch --interval 10         # poll every 10 seconds
+browse status --watch --json                # NDJSON stream for monitoring
+browse status --exit-code                   # exit 0/1 for CI health probes
 ```
 
 ### Flows and assertions
@@ -421,7 +425,7 @@ Measured with `browse benchmark`:
 | `a11y [@eN]` | Accessibility audit (`--standard`, `--json`, `--include`, `--exclude`) |
 | `session create\|list\|close` | Manage isolated browser sessions |
 | `ping` | Check if daemon is alive |
-| `status` | Show daemon status and uptime (`--json` for machine-readable) |
+| `status` | Show daemon status and uptime (`--json`, `--watch`, `--exit-code`) |
 | `dialog accept\|dismiss\|status\|auto-*` | Handle browser dialogs |
 | `download wait` | Wait for and save file downloads (`--save-to`, `--expect-type`, `--expect-min-size`, `--expect-max-size`) |
 | `frame list\|switch\|main` | Navigate and inspect iframes |

--- a/SKILL.md
+++ b/SKILL.md
@@ -67,7 +67,7 @@ For configured applications, `browse healthcheck` gives a quick pass/fail across
 | **Flows** | `flow list`, `flow <name> --var key=value` (`--reporter junit`, `--dry-run`, `--stream`), `healthcheck` (`--reporter junit`, `--parallel`, `--concurrency`), `test-matrix --roles r1,r2 --flow <name>`, `diff --baseline <url> --current <url>` |
 | **Sessions** | `session list/create/close`, `--session <name>` on any command |
 | **Tracing** | `trace start` (`--screenshots`, `--snapshots`), `trace stop --out <path>`, `trace view [<path>] --latest --port <n>`, `trace list`, `trace status` |
-| **Tooling** | `init`, `report --out <path>`, `replay --out <path>`, `flow-share export/import/list/install/publish`, `screenshots list/clean/count`, `completions bash/zsh/fish`, `status --json` |
+| **Tooling** | `init`, `report --out <path>`, `replay --out <path>`, `flow-share export/import/list/install/publish`, `screenshots list/clean/count`, `completions bash/zsh/fish`, `status [--json] [--watch] [--exit-code]` |
 
 Run `browse help <command>` for flags and detailed usage — don't guess at flags.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1083,7 +1083,7 @@ Check if the daemon is alive. Returns `pong`.
 ### status
 
 ```
-browse status [--json]
+browse status [--json] [--watch [--interval N]] [--exit-code]
 ```
 
 Show sessions, uptime, URLs, and tab counts per session. With `--json`, outputs machine-readable JSON including memory usage, browser version, daemon PID, and per-session details.
@@ -1091,6 +1091,29 @@ Show sessions, uptime, URLs, and tab counts per session. With `--json`, outputs 
 | Flag | Description |
 |------|-------------|
 | `--json` | Output as JSON with extended details (memory, browser version, PID) |
+| `--watch` | Continuously poll and display status. Plain text clears and redraws; with `--json` outputs one JSON object per line (NDJSON) |
+| `--interval <seconds>` | Polling interval for `--watch` (default: 5) |
+| `--exit-code` | Exit `0` if the daemon is healthy, `1` if unhealthy. Useful for Kubernetes/Docker health probes |
+
+**Examples:**
+
+```bash
+browse status
+browse status --json
+browse status --watch
+browse status --watch --interval 10
+browse status --watch --json
+browse status --exit-code
+```
+
+**Container health probe example:**
+
+```yaml
+livenessProbe:
+  exec:
+    command: ["browse", "status", "--exit-code"]
+  periodSeconds: 10
+```
 
 ### benchmark
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,6 +107,42 @@ export function parseArgs(argv: string[]): ParsedArgs {
 	return { cmd: cmd as string, args, timeout, session, json, config };
 }
 
+/**
+ * Extract status-specific CLI flags (--watch, --interval, --exit-code) from args.
+ * These are handled client-side and not sent to the daemon.
+ */
+export function extractStatusFlags(args: string[]): {
+	watch: boolean;
+	interval: number;
+	exitCode: boolean;
+	cleanArgs: string[];
+} {
+	let watch = false;
+	let interval = 5;
+	let exitCode = false;
+	const cleanArgs: string[] = [];
+
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "--watch") {
+			watch = true;
+		} else if (args[i] === "--interval") {
+			if (i + 1 < args.length) {
+				const val = Number.parseInt(args[i + 1], 10);
+				if (!Number.isNaN(val) && val > 0) {
+					interval = val;
+				}
+				i++; // skip the value
+			}
+		} else if (args[i] === "--exit-code") {
+			exitCode = true;
+		} else {
+			cleanArgs.push(args[i]);
+		}
+	}
+
+	return { watch, interval, exitCode, cleanArgs };
+}
+
 export function formatOutput(response: Response): {
 	output: string;
 	isError: boolean;
@@ -252,6 +288,69 @@ async function runCli(): Promise<void> {
 			process.exit(1);
 		}
 		return;
+	}
+
+	// Status command: handle --watch, --interval, --exit-code client-side
+	if (cmd === "status") {
+		const statusFlags = extractStatusFlags(args);
+		const retryDeps = {
+			sendRequest: (c: string, a: string[]) =>
+				sendRequest(
+					DEFAULT_CONFIG.socketPath,
+					c,
+					a,
+					timeout,
+					session,
+					json,
+					readToken(),
+				),
+			spawnDaemon: () => spawnDaemon(configPath),
+			cleanupStaleFiles: () => cleanupFiles(DEFAULT_CONFIG),
+		};
+
+		if (statusFlags.exitCode) {
+			try {
+				await sendWithRetry(retryDeps, cmd, statusFlags.cleanArgs);
+				process.exit(0);
+			} catch {
+				process.exit(1);
+			}
+		}
+
+		if (statusFlags.watch) {
+			const intervalMs = statusFlags.interval * 1000;
+
+			// eslint-disable-next-line no-constant-condition
+			while (true) {
+				try {
+					const response = await sendWithRetry(
+						retryDeps,
+						cmd,
+						statusFlags.cleanArgs,
+					);
+					const { output, isError } = formatOutput(response);
+					if (json) {
+						// NDJSON: one JSON object per line
+						process.stdout.write(`${output}\n`);
+					} else {
+						// Clear screen and rewrite for human-readable output
+						process.stdout.write(`\x1b[2J\x1b[H${output}\n`);
+					}
+					if (isError) {
+						process.exitCode = 1;
+					}
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					if (json) {
+						process.stdout.write(`${JSON.stringify({ error: msg })}\n`);
+					} else {
+						process.stdout.write(`\x1b[2J\x1b[HError: ${msg}\n`);
+					}
+					process.exitCode = 1;
+				}
+				await Bun.sleep(intervalMs);
+			}
+		}
 	}
 
 	let response: Response;

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -106,7 +106,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 	version: [],
 	session: ["--isolated"],
 	ping: [],
-	status: ["--json"],
+	status: ["--json", "--watch", "--interval", "--exit-code"],
 	dialog: [],
 	download: [
 		"--save-to",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -129,7 +129,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 	quit: [],
 	session: ["--isolated"],
 	ping: [],
-	status: [],
+	status: ["--watch", "--interval", "--exit-code"],
 	dialog: [],
 	download: [
 		"--save-to",

--- a/src/help.ts
+++ b/src/help.ts
@@ -330,12 +330,24 @@ Use --session <name> on any command to route it to a named session:
 	},
 	status: {
 		summary: "Show daemon status and health info",
-		usage: `browse status [--json]
+		usage: `browse status [--json] [--watch [--interval N]] [--exit-code]
 
 Shows daemon PID, uptime, memory usage, browser version, session count,
 total tabs, and per-session details.
 
-With --json, returns structured JSON with all health metrics for CI readiness checks.`,
+Flags:
+  --json               Returns structured JSON with all health metrics
+  --watch              Continuously poll and display status
+  --interval <seconds> Polling interval for --watch (default: 5)
+  --exit-code          Exit 0 if daemon is healthy, 1 if unhealthy (for CI/container probes)
+
+Examples:
+  browse status                            One-shot status
+  browse status --json                     Structured JSON output
+  browse status --watch                    Live-updating status (every 5s)
+  browse status --watch --interval 10      Poll every 10 seconds
+  browse status --watch --json             NDJSON stream for monitoring
+  browse status --exit-code                Health probe (exit code only)`,
 	},
 	dialog: {
 		summary: "Handle browser dialogs (alert, confirm, prompt)",

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { formatOutput, parseArgs } from "../src/cli.ts";
+import { extractStatusFlags, formatOutput, parseArgs } from "../src/cli.ts";
 
 describe("parseArgs", () => {
 	test("parses goto command with URL", () => {
@@ -387,6 +387,88 @@ describe("parseArgs", () => {
 			session: undefined,
 			json: false,
 			config: "/tmp/cfg.json",
+		});
+	});
+});
+
+describe("extractStatusFlags", () => {
+	test("returns defaults when no flags present", () => {
+		const result = extractStatusFlags([]);
+		expect(result).toEqual({
+			watch: false,
+			interval: 5,
+			exitCode: false,
+			cleanArgs: [],
+		});
+	});
+
+	test("extracts --watch flag", () => {
+		const result = extractStatusFlags(["--watch"]);
+		expect(result).toEqual({
+			watch: true,
+			interval: 5,
+			exitCode: false,
+			cleanArgs: [],
+		});
+	});
+
+	test("extracts --interval with value", () => {
+		const result = extractStatusFlags(["--watch", "--interval", "10"]);
+		expect(result).toEqual({
+			watch: true,
+			interval: 10,
+			exitCode: false,
+			cleanArgs: [],
+		});
+	});
+
+	test("extracts --exit-code flag", () => {
+		const result = extractStatusFlags(["--exit-code"]);
+		expect(result).toEqual({
+			watch: false,
+			interval: 5,
+			exitCode: true,
+			cleanArgs: [],
+		});
+	});
+
+	test("preserves unrelated args", () => {
+		const result = extractStatusFlags(["--exit-code", "--json"]);
+		expect(result).toEqual({
+			watch: false,
+			interval: 5,
+			exitCode: true,
+			cleanArgs: ["--json"],
+		});
+	});
+
+	test("invalid --interval value defaults to 5", () => {
+		const result = extractStatusFlags(["--watch", "--interval", "abc"]);
+		expect(result).toEqual({
+			watch: true,
+			interval: 5,
+			exitCode: false,
+			cleanArgs: [],
+		});
+	});
+
+	test("--interval without value defaults to 5", () => {
+		const result = extractStatusFlags(["--watch", "--interval"]);
+		expect(result).toEqual({
+			watch: true,
+			interval: 5,
+			exitCode: false,
+			cleanArgs: [],
+		});
+	});
+
+	test("--interval 0 or negative defaults to 5", () => {
+		const result = extractStatusFlags(["--watch", "--interval", "0"]);
+		expect(result).toEqual({
+			watch: true,
+			interval: 5,
+			exitCode: false,
+			cleanArgs: [],
 		});
 	});
 });

--- a/test/new-commands.test.ts
+++ b/test/new-commands.test.ts
@@ -72,6 +72,57 @@ function mockDeps(
 	};
 }
 
+function sendJsonCommand(
+	socketPath: string,
+	cmd: string,
+	args: string[] = [],
+	timeoutMs = 5_000,
+): Promise<Response> {
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		const settle = (fn: () => void) => {
+			if (!settled) {
+				settled = true;
+				fn();
+			}
+		};
+
+		const client = connect(socketPath, () => {
+			client.write(`${JSON.stringify({ cmd, args, json: true })}\n`);
+		});
+
+		const timer = setTimeout(() => {
+			settle(() => {
+				client.destroy();
+				reject(
+					new Error(
+						`sendJsonCommand timed out after ${timeoutMs}ms: ${cmd} ${args.join(" ")}`,
+					),
+				);
+			});
+		}, timeoutMs);
+
+		let data = "";
+		client.on("data", (chunk) => {
+			data += chunk.toString();
+		});
+		client.on("end", () => {
+			clearTimeout(timer);
+			settle(() => {
+				try {
+					resolve(JSON.parse(data.trim()));
+				} catch {
+					reject(new Error(`Failed to parse response: ${data}`));
+				}
+			});
+		});
+		client.on("error", (err) => {
+			clearTimeout(timer);
+			settle(() => reject(err));
+		});
+	});
+}
+
 function sendCommand(
 	socketPath: string,
 	cmd: string,
@@ -165,6 +216,61 @@ describe("status command", () => {
 				expect(r.data).toContain("Sessions:");
 				expect(r.data).toContain("Uptime:");
 				expect(r.data).toContain("default:");
+			}
+		} finally {
+			await shutdown();
+		}
+	});
+});
+
+describe("status --json command", () => {
+	test("returns structured JSON with all health metrics", async () => {
+		const config = testPaths();
+		const page = mockPage();
+		const { shutdown } = await startServer(
+			mockDeps(page),
+			config,
+			async () => {},
+		);
+		try {
+			const r = await sendCommand(config.socketPath, "status", [], 5_000);
+			expect(r.ok).toBe(true);
+			if (r.ok) {
+				// Send with json flag
+				const jr = await sendCommand(config.socketPath, "status", [], 5_000);
+				expect(jr.ok).toBe(true);
+			}
+		} finally {
+			await shutdown();
+		}
+	});
+
+	test("JSON response contains required health fields", async () => {
+		const config = testPaths();
+		const page = mockPage();
+		const { shutdown } = await startServer(
+			mockDeps(page),
+			config,
+			async () => {},
+		);
+		try {
+			const r = await sendJsonCommand(config.socketPath, "status");
+			expect(r.ok).toBe(true);
+			if (r.ok) {
+				const data = JSON.parse(r.data);
+				expect(data).toHaveProperty("uptime");
+				expect(data).toHaveProperty("uptimeMs");
+				expect(data).toHaveProperty("memory");
+				expect(data.memory).toHaveProperty("rss");
+				expect(data.memory).toHaveProperty("rssMb");
+				expect(data).toHaveProperty("sessions");
+				expect(data).toHaveProperty("totalTabs");
+				expect(data).toHaveProperty("browserVersion");
+				expect(data).toHaveProperty("daemonPid");
+				expect(data).toHaveProperty("sessionsDetail");
+				expect(typeof data.uptime).toBe("number");
+				expect(typeof data.memory.rssMb).toBe("number");
+				expect(typeof data.daemonPid).toBe("number");
 			}
 		} finally {
 			await shutdown();


### PR DESCRIPTION
## Summary

- Adds `--watch` flag to `browse status` for continuous health monitoring with configurable `--interval` (default 5s)
- Adds `--exit-code` flag for CI/container health probes (exit 0 if healthy, 1 if unhealthy)
- Plain text watch mode clears and redraws; `--json --watch` outputs NDJSON for easy piping
- All flags handled client-side — daemon protocol unchanged

### Usage

```bash
browse status --watch                # live-updating status
browse status --watch --interval 10  # poll every 10s
browse status --watch --json         # NDJSON stream
browse status --exit-code            # health probe
```

### Container health probe

```yaml
livenessProbe:
  exec:
    command: ["browse", "status", "--exit-code"]
  periodSeconds: 10
```

## Changes

- `src/cli.ts` — `extractStatusFlags()` function, watch loop, and exit-code handling
- `src/daemon.ts` — add new flags to `KNOWN_FLAGS`
- `src/help.ts` — updated status command help
- `src/completions.ts` — added new flags for shell completions
- `docs/commands.md` — full documentation with examples
- `README.md` — updated daemon health section and commands table
- `SKILL.md` — updated tooling row
- `test/cli.test.ts` — 8 tests for `extractStatusFlags` (flag extraction, defaults, edge cases)
- `test/new-commands.test.ts` — tests for status JSON response structure

## Test plan

- [x] All `extractStatusFlags` parsing tests pass (defaults, flag extraction, invalid values, edge cases)
- [x] Status JSON response structure validated
- [x] Existing tests unaffected (full suite passes)
- [x] Lint and format pass (`bun run check:fix`)

Closes #86