### PR TITLE
feat: add --webhook flag for flow and healthcheck notifications

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -64,7 +64,7 @@ For configured applications, `browse healthcheck` gives a quick pass/fail across
 | **Tabs** | `tab list/new/switch/close` |
 | **Assert** | `assert visible/text-contains/url-contains/...`, `assert-ai "<visual assertion>"` |
 | **Accessibility** | `a11y` (full page), `a11y @eN` (element), `a11y --standard wcag2aa`, `a11y --json` |
-| **Flows** | `flow list`, `flow <name> --var key=value` (`--reporter junit`, `--dry-run`, `--stream`), `healthcheck` (`--reporter junit`, `--parallel`, `--concurrency`), `test-matrix --roles r1,r2 --flow <name>`, `diff --baseline <url> --current <url>` |
+| **Flows** | `flow list`, `flow <name> --var key=value` (`--reporter junit`, `--dry-run`, `--stream`, `--webhook <url>`), `healthcheck` (`--reporter junit`, `--parallel`, `--concurrency`, `--webhook <url>`), `test-matrix --roles r1,r2 --flow <name>`, `diff --baseline <url> --current <url>` |
 | **Sessions** | `session list/create/close`, `--session <name>` on any command |
 | **Tracing** | `trace start` (`--screenshots`, `--snapshots`), `trace stop --out <path>`, `trace view [<path>] --latest --port <n>`, `trace list`, `trace status` |
 | **Tooling** | `init`, `report --out <path>`, `replay --out <path>`, `flow-share export/import/list/install/publish`, `screenshots list/clean/count`, `completions bash/zsh/fish`, `status [--json] [--watch] [--exit-code]` |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -731,7 +731,7 @@ List all defined flows.
 ### flow
 
 ```
-browse flow <name> [--var k=v ...] [--continue-on-error] [--reporter junit] [--dry-run] [--stream]
+browse flow <name> [--var k=v ...] [--continue-on-error] [--reporter junit] [--dry-run] [--stream] [--webhook <url>]
 ```
 
 Execute a named flow defined in `browse.config.json`.
@@ -743,6 +743,7 @@ Execute a named flow defined in `browse.config.json`.
 | `--reporter <format>` | Output format: `junit` (JUnit XML for CI integration) |
 | `--dry-run` | Preview steps without executing them |
 | `--stream` | Output real-time NDJSON with one object per step |
+| `--webhook <url>` | POST a JSON result payload to the URL on completion |
 
 **Examples:**
 
@@ -752,12 +753,13 @@ browse flow checkout --continue-on-error
 browse flow smoke-test --reporter junit > results.xml
 browse flow signup --dry-run
 browse flow smoke-test --stream
+browse flow smoke-test --webhook https://hooks.slack.com/services/T.../B.../xxx
 ```
 
 ### healthcheck
 
 ```
-browse healthcheck [--var k=v ...] [--no-screenshots] [--reporter junit] [--parallel] [--concurrency N]
+browse healthcheck [--var k=v ...] [--no-screenshots] [--reporter junit] [--parallel] [--concurrency N] [--webhook <url>]
 ```
 
 Run a healthcheck across configured pages defined in `browse.config.json`.
@@ -769,6 +771,7 @@ Run a healthcheck across configured pages defined in `browse.config.json`.
 | `--reporter <format>` | Output format: `junit` (JUnit XML for CI integration) |
 | `--parallel` | Check pages concurrently instead of sequentially |
 | `--concurrency N` | Max concurrent pages when `--parallel` is set (default: 5) |
+| `--webhook <url>` | POST a JSON result payload to the URL on completion |
 
 **Examples:**
 
@@ -778,6 +781,7 @@ browse healthcheck --var env=staging
 browse healthcheck --no-screenshots
 browse healthcheck --reporter junit > results.xml
 browse healthcheck --parallel --concurrency 8
+browse healthcheck --webhook https://hooks.slack.com/services/T.../B.../xxx
 ```
 
 ---

--- a/docs/flows-and-healthchecks.md
+++ b/docs/flows-and-healthchecks.md
@@ -189,6 +189,41 @@ browse flow smoke-test --stream
 
 Each line is a JSON object with step index, description, status, and timing.
 
+### Webhook Notifications
+
+Send results to an external URL on completion:
+
+```sh
+browse flow smoke-test --webhook https://hooks.slack.com/services/T.../B.../xxx
+browse flow checkout --webhook https://your-ci.example.com/callback --continue-on-error
+```
+
+The `--webhook` flag POSTs a JSON payload when the flow finishes:
+
+```json
+{
+  "type": "flow",
+  "name": "smoke-test",
+  "status": "passed",
+  "summary": { "total": 5, "passed": 5, "failed": 0 },
+  "duration_ms": 1234,
+  "failures": [],
+  "timestamp": "2026-03-19T12:00:00.000Z"
+}
+```
+
+Failed flows include failure details:
+
+```json
+{
+  "failures": [
+    { "step": 3, "error": "Assertion failed: expected 'Dashboard' in title" }
+  ]
+}
+```
+
+The webhook is fire-and-forget — network errors or non-2xx responses are silently ignored so they never block command output.
+
 ### Error Handling
 
 - By default, a flow stops on the first failure
@@ -257,6 +292,30 @@ browse healthcheck --parallel --concurrency 4                    # check pages c
 - `--reporter junit` -- Output results as JUnit XML for CI integration
 - `--parallel` -- Check pages concurrently instead of sequentially
 - `--concurrency N` -- Max concurrent pages when `--parallel` is set (default: 5)
+- `--webhook <url>` -- POST a JSON result payload to the URL on completion
+
+### Webhook Notifications
+
+Send healthcheck results to an external URL on completion:
+
+```sh
+browse healthcheck --var base_url=https://staging.example.com --webhook https://hooks.slack.com/services/T.../B.../xxx
+```
+
+The `--webhook` flag POSTs a JSON payload when the healthcheck finishes:
+
+```json
+{
+  "type": "healthcheck",
+  "status": "failed",
+  "summary": { "total": 3, "passed": 2, "failed": 1 },
+  "duration_ms": 2500,
+  "failures": [
+    { "page": "API Health", "error": "Navigation failed: net::ERR_CONNECTION_REFUSED" }
+  ],
+  "timestamp": "2026-03-19T12:00:00.000Z"
+}
+```
 
 ## See Also
 

--- a/src/commands/flow.ts
+++ b/src/commands/flow.ts
@@ -10,6 +10,11 @@ import {
 } from "../flow-runner.ts";
 import type { Response } from "../protocol.ts";
 import { formatFlowJUnit } from "../reporters.ts";
+import {
+	formatFlowWebhookPayload,
+	parseWebhookFlag,
+	sendWebhook,
+} from "../webhook.ts";
 import type { ConsoleEntry } from "./console.ts";
 import type { NetworkEntry } from "./network.ts";
 
@@ -104,6 +109,13 @@ export async function handleFlow(
 		}
 	}
 
+	// Parse webhook flag
+	const webhookResult = parseWebhookFlag(args.slice(1));
+	if (webhookResult.error) {
+		return { ok: false, error: webhookResult.error };
+	}
+	const webhookUrl = webhookResult.url;
+
 	// Validate required variables
 	if (flow.variables && flow.variables.length > 0) {
 		const missing = flow.variables.filter((v) => !(v in vars));
@@ -155,6 +167,12 @@ export async function handleFlow(
 	const durationMs = Date.now() - startTime;
 
 	const allPassed = results.every((r) => r.passed);
+
+	// Fire webhook notification (non-blocking)
+	if (webhookUrl) {
+		const payload = formatFlowWebhookPayload(flowName, results, durationMs);
+		sendWebhook(webhookUrl, payload);
+	}
 
 	// Streaming output returns NDJSON
 	if (stream) {

--- a/src/commands/healthcheck.ts
+++ b/src/commands/healthcheck.ts
@@ -11,6 +11,11 @@ import type {
 import { interpolateVars, parseVars } from "../flow-runner.ts";
 import type { Response } from "../protocol.ts";
 import { formatHealthcheckJUnit } from "../reporters.ts";
+import {
+	formatHealthcheckWebhookPayload,
+	parseWebhookFlag,
+	sendWebhook,
+} from "../webhook.ts";
 import { evaluateAssertCondition } from "./assert.ts";
 import { type ConsoleEntry, formatConsoleEntries } from "./console.ts";
 import type { NetworkEntry } from "./network.ts";
@@ -28,6 +33,7 @@ export function parseHealthcheckArgs(args: string[]): {
 	parallel: boolean;
 	concurrency: number;
 	reporter?: string;
+	webhookUrl?: string;
 	error?: string;
 } {
 	const vars = parseVars(args);
@@ -64,7 +70,26 @@ export function parseHealthcheckArgs(args: string[]): {
 			}
 		}
 	}
-	return { vars, noScreenshots, parallel, concurrency, reporter };
+
+	const webhookResult = parseWebhookFlag(args);
+	if (webhookResult.error) {
+		return {
+			vars,
+			noScreenshots,
+			parallel,
+			concurrency,
+			error: webhookResult.error,
+		};
+	}
+
+	return {
+		vars,
+		noScreenshots,
+		parallel,
+		concurrency,
+		reporter,
+		webhookUrl: webhookResult.url,
+	};
 }
 
 function slugify(name: string): string {
@@ -139,7 +164,8 @@ export async function handleHealthcheck(
 	if (parsed.error) {
 		return { ok: false, error: parsed.error };
 	}
-	const { vars, noScreenshots, parallel, concurrency, reporter } = parsed;
+	const { vars, noScreenshots, parallel, concurrency, reporter, webhookUrl } =
+		parsed;
 	const pages = config.healthcheck.pages;
 	const startTime = Date.now();
 	const results: PageResult[] = [];
@@ -296,6 +322,12 @@ export async function handleHealthcheck(
 	const totalCount = results.length;
 	const allPassed = passedCount === totalCount;
 	const durationMs = Date.now() - startTime;
+
+	// Fire webhook notification (non-blocking)
+	if (webhookUrl) {
+		const payload = formatHealthcheckWebhookPayload(results, durationMs);
+		sendWebhook(webhookUrl, payload);
+	}
 
 	if (reporter === "junit") {
 		const junit = formatHealthcheckJUnit(results, durationMs);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -104,7 +104,14 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 	"auth-state": [],
 	login: ["--env"],
 	tab: [],
-	flow: ["--var", "--continue-on-error", "--reporter", "--dry-run", "--stream"],
+	flow: [
+		"--var",
+		"--continue-on-error",
+		"--reporter",
+		"--dry-run",
+		"--stream",
+		"--webhook",
+	],
 	assert: ["--var", "--json"],
 	healthcheck: [
 		"--var",
@@ -112,6 +119,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 		"--reporter",
 		"--parallel",
 		"--concurrency",
+		"--webhook",
 	],
 	wipe: [],
 	benchmark: ["--iterations"],

--- a/src/help.ts
+++ b/src/help.ts
@@ -133,7 +133,7 @@ browse tab close [index]     Close tab (closes active tab if no index)`,
 	flow: {
 		summary: "Execute a named flow",
 		usage: `browse flow list                          List defined flows
-browse flow <name> [--var k=v ...] [--continue-on-error] [--reporter junit] [--dry-run] [--stream]
+browse flow <name> [--var k=v ...] [--continue-on-error] [--reporter junit] [--dry-run] [--stream] [--webhook <url>]
 
 Flags:
   --var key=value       Pass variables to flow (repeatable)
@@ -141,6 +141,7 @@ Flags:
   --reporter <format>   Output format: junit (JUnit XML for CI integration)
   --dry-run             Preview step plan without executing
   --stream              Emit step results as NDJSON as they complete
+  --webhook <url>       POST a JSON result payload to the URL on completion
 
 Flows are defined in browse.config.json. Flows support conditional logic
 (if/else) and loops (while) with condition expressions.`,
@@ -165,7 +166,7 @@ Flags:
 	},
 	healthcheck: {
 		summary: "Run healthcheck across configured pages",
-		usage: `browse healthcheck [--var k=v ...] [--no-screenshots] [--reporter junit] [--parallel] [--concurrency N]
+		usage: `browse healthcheck [--var k=v ...] [--no-screenshots] [--reporter junit] [--parallel] [--concurrency N] [--webhook <url>]
 
 Flags:
   --var key=value       Pass variables for URL interpolation (repeatable)
@@ -173,6 +174,7 @@ Flags:
   --reporter <format>   Output format: junit (JUnit XML for CI integration)
   --parallel            Check pages concurrently using separate browser tabs
   --concurrency <N>     Max pages to check in parallel (default: 5, requires --parallel)
+  --webhook <url>       POST a JSON result payload to the URL on completion
 
 Pages are defined in browse.config.json.`,
 	},

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,0 +1,136 @@
+import type { StepResult } from "./flow-runner.ts";
+
+export type WebhookPayload = {
+	type: "flow" | "healthcheck";
+	name?: string;
+	status: "passed" | "failed";
+	summary: {
+		total: number;
+		passed: number;
+		failed: number;
+	};
+	duration_ms: number;
+	failures: { step?: number; page?: string; error: string }[];
+	timestamp: string;
+};
+
+export type HealthcheckPageForWebhook = {
+	name: string;
+	url: string;
+	passed: boolean;
+	error?: string;
+	assertionResults: { label: string; passed: boolean; reason?: string }[];
+	consoleErrors: { text: string }[];
+	consoleWarnings: { text: string }[];
+};
+
+/**
+ * Parse the --webhook <url> flag from command arguments.
+ */
+export function parseWebhookFlag(args: string[]): {
+	url?: string;
+	error?: string;
+} {
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "--webhook") {
+			if (i + 1 >= args.length || args[i + 1].startsWith("--")) {
+				return { error: "Missing value for --webhook. Provide a URL." };
+			}
+			return { url: args[i + 1] };
+		}
+	}
+	return {};
+}
+
+/**
+ * Format a flow result into a webhook payload.
+ */
+export function formatFlowWebhookPayload(
+	flowName: string,
+	results: StepResult[],
+	durationMs: number,
+): WebhookPayload {
+	const passed = results.filter((r) => r.passed).length;
+	const failed = results.filter((r) => !r.passed).length;
+
+	return {
+		type: "flow",
+		name: flowName,
+		status: failed > 0 ? "failed" : "passed",
+		summary: {
+			total: results.length,
+			passed,
+			failed,
+		},
+		duration_ms: durationMs,
+		failures: results
+			.filter((r) => !r.passed)
+			.map((r) => ({
+				step: r.stepNum,
+				error: r.error ?? `Step ${r.stepNum} failed`,
+			})),
+		timestamp: new Date().toISOString(),
+	};
+}
+
+/**
+ * Format a healthcheck result into a webhook payload.
+ */
+export function formatHealthcheckWebhookPayload(
+	results: HealthcheckPageForWebhook[],
+	durationMs: number,
+): WebhookPayload {
+	const passed = results.filter((r) => r.passed).length;
+	const failed = results.filter((r) => !r.passed).length;
+
+	return {
+		type: "healthcheck",
+		status: failed > 0 ? "failed" : "passed",
+		summary: {
+			total: results.length,
+			passed,
+			failed,
+		},
+		duration_ms: durationMs,
+		failures: results
+			.filter((r) => !r.passed)
+			.map((r) => {
+				const errors: string[] = [];
+				if (r.error) {
+					errors.push(r.error);
+				}
+				for (const ar of r.assertionResults) {
+					if (!ar.passed && ar.reason) {
+						errors.push(`${ar.label}: ${ar.reason}`);
+					}
+				}
+				return {
+					page: r.name,
+					error: errors.join("; ") || "Page check failed",
+				};
+			}),
+		timestamp: new Date().toISOString(),
+	};
+}
+
+/**
+ * Send a webhook payload to the given URL. Fire-and-forget — does not throw.
+ */
+export async function sendWebhook(
+	url: string,
+	payload: unknown,
+	headers?: Record<string, string>,
+): Promise<void> {
+	try {
+		await fetch(url, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				...headers,
+			},
+			body: JSON.stringify(payload),
+		});
+	} catch {
+		// Fire-and-forget: swallow errors to avoid blocking the command
+	}
+}

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { handleFlow } from "../src/commands/flow.ts";
+import { parseHealthcheckArgs } from "../src/commands/healthcheck.ts";
+import type { BrowseConfig } from "../src/config.ts";
+import type { StepResult } from "../src/flow-runner.ts";
+import {
+	formatFlowWebhookPayload,
+	formatHealthcheckWebhookPayload,
+	parseWebhookFlag,
+	sendWebhook,
+} from "../src/webhook.ts";
+
+describe("parseWebhookFlag", () => {
+	test("extracts URL from --webhook flag", () => {
+		const result = parseWebhookFlag([
+			"--webhook",
+			"https://hooks.slack.com/test",
+		]);
+		expect(result.url).toBe("https://hooks.slack.com/test");
+		expect(result.error).toBeUndefined();
+	});
+
+	test("returns undefined when --webhook is absent", () => {
+		const result = parseWebhookFlag(["--reporter", "junit"]);
+		expect(result.url).toBeUndefined();
+		expect(result.error).toBeUndefined();
+	});
+
+	test("returns error when --webhook has no value", () => {
+		const result = parseWebhookFlag(["--webhook"]);
+		expect(result.url).toBeUndefined();
+		expect(result.error).toContain("Missing value for --webhook");
+	});
+
+	test("returns error when --webhook value starts with --", () => {
+		const result = parseWebhookFlag(["--webhook", "--reporter"]);
+		expect(result.url).toBeUndefined();
+		expect(result.error).toContain("Missing value for --webhook");
+	});
+
+	test("works alongside other flags", () => {
+		const result = parseWebhookFlag([
+			"--reporter",
+			"junit",
+			"--webhook",
+			"https://example.com/hook",
+			"--continue-on-error",
+		]);
+		expect(result.url).toBe("https://example.com/hook");
+		expect(result.error).toBeUndefined();
+	});
+});
+
+describe("formatFlowWebhookPayload", () => {
+	test("formats a passing flow payload", () => {
+		const results: StepResult[] = [
+			{ stepNum: 1, description: "goto https://example.com", passed: true },
+			{
+				stepNum: 2,
+				description: 'assert textContains "Welcome"',
+				passed: true,
+			},
+		];
+		const payload = formatFlowWebhookPayload("smoke-test", results, 1234);
+
+		expect(payload.type).toBe("flow");
+		expect(payload.name).toBe("smoke-test");
+		expect(payload.status).toBe("passed");
+		expect(payload.summary.total).toBe(2);
+		expect(payload.summary.passed).toBe(2);
+		expect(payload.summary.failed).toBe(0);
+		expect(payload.duration_ms).toBe(1234);
+		expect(payload.failures).toEqual([]);
+		expect(payload.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+	});
+
+	test("formats a failing flow payload with failure details", () => {
+		const results: StepResult[] = [
+			{ stepNum: 1, description: "goto https://example.com", passed: true },
+			{
+				stepNum: 2,
+				description: 'assert textContains "Dashboard"',
+				passed: false,
+				error: "Text not found: Dashboard",
+			},
+			{ stepNum: 3, description: "screenshot", passed: true },
+		];
+		const payload = formatFlowWebhookPayload("login-flow", results, 5678);
+
+		expect(payload.status).toBe("failed");
+		expect(payload.summary.total).toBe(3);
+		expect(payload.summary.passed).toBe(2);
+		expect(payload.summary.failed).toBe(1);
+		expect(payload.failures).toHaveLength(1);
+		expect(payload.failures[0].step).toBe(2);
+		expect(payload.failures[0].error).toBe("Text not found: Dashboard");
+	});
+});
+
+describe("formatHealthcheckWebhookPayload", () => {
+	test("formats a passing healthcheck payload", () => {
+		const results = [
+			{
+				name: "Homepage",
+				url: "https://example.com",
+				passed: true,
+				consoleErrors: [],
+				consoleWarnings: [],
+				assertionResults: [],
+			},
+			{
+				name: "API Health",
+				url: "https://example.com/api/health",
+				passed: true,
+				consoleErrors: [],
+				consoleWarnings: [],
+				assertionResults: [],
+			},
+		];
+		const payload = formatHealthcheckWebhookPayload(results, 2000);
+
+		expect(payload.type).toBe("healthcheck");
+		expect(payload.status).toBe("passed");
+		expect(payload.summary.total).toBe(2);
+		expect(payload.summary.passed).toBe(2);
+		expect(payload.summary.failed).toBe(0);
+		expect(payload.duration_ms).toBe(2000);
+		expect(payload.failures).toEqual([]);
+		expect(payload.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+	});
+
+	test("formats a failing healthcheck payload with failure details", () => {
+		const results = [
+			{
+				name: "Dashboard",
+				url: "https://example.com/dashboard",
+				passed: false,
+				error: "Navigation failed: net::ERR_CONNECTION_REFUSED",
+				consoleErrors: [],
+				consoleWarnings: [],
+				assertionResults: [],
+			},
+			{
+				name: "Settings",
+				url: "https://example.com/settings",
+				passed: false,
+				consoleErrors: [],
+				consoleWarnings: [],
+				assertionResults: [
+					{
+						label: 'visible ".settings-form"',
+						passed: false,
+						reason: "Element not visible",
+					},
+				],
+			},
+		];
+		const payload = formatHealthcheckWebhookPayload(results, 3000);
+
+		expect(payload.status).toBe("failed");
+		expect(payload.summary.total).toBe(2);
+		expect(payload.summary.passed).toBe(0);
+		expect(payload.summary.failed).toBe(2);
+		expect(payload.failures).toHaveLength(2);
+		expect(payload.failures[0].page).toBe("Dashboard");
+		expect(payload.failures[0].error).toBe(
+			"Navigation failed: net::ERR_CONNECTION_REFUSED",
+		);
+		expect(payload.failures[1].page).toBe("Settings");
+		expect(payload.failures[1].error).toContain("Element not visible");
+	});
+});
+
+describe("sendWebhook", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	test("POSTs JSON payload to the given URL", async () => {
+		const fetchMock = mock(() =>
+			Promise.resolve(new Response("OK", { status: 200 })),
+		);
+		globalThis.fetch = fetchMock;
+
+		const payload = { type: "flow", name: "test", status: "passed" };
+		await sendWebhook("https://hooks.example.com/test", payload);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe("https://hooks.example.com/test");
+		expect(init.method).toBe("POST");
+		expect(init.headers["Content-Type"]).toBe("application/json");
+		expect(JSON.parse(init.body)).toEqual(payload);
+	});
+
+	test("includes custom headers when provided", async () => {
+		const fetchMock = mock(() =>
+			Promise.resolve(new Response("OK", { status: 200 })),
+		);
+		globalThis.fetch = fetchMock;
+
+		const payload = { type: "flow", name: "test", status: "passed" };
+		await sendWebhook("https://hooks.example.com/test", payload, {
+			Authorization: "Bearer secret",
+		});
+
+		const [, init] = fetchMock.mock.calls[0];
+		expect(init.headers.Authorization).toBe("Bearer secret");
+		expect(init.headers["Content-Type"]).toBe("application/json");
+	});
+
+	test("does not throw on fetch failure", async () => {
+		globalThis.fetch = mock(() => Promise.reject(new Error("Network error")));
+
+		const payload = { type: "flow", name: "test", status: "passed" };
+		// Should not throw
+		await sendWebhook("https://hooks.example.com/test", payload);
+	});
+
+	test("does not throw on non-2xx response", async () => {
+		globalThis.fetch = mock(() =>
+			Promise.resolve(new Response("Server Error", { status: 500 })),
+		);
+
+		const payload = { type: "flow", name: "test", status: "passed" };
+		// Should not throw
+		await sendWebhook("https://hooks.example.com/test", payload);
+	});
+});
+
+// --- Integration tests: --webhook flag in commands ---
+
+const BASE_CONFIG: BrowseConfig = {
+	environments: {
+		staging: {
+			loginUrl: "https://example.com/login",
+			userEnvVar: "U",
+			passEnvVar: "P",
+			successCondition: { urlContains: "/dashboard" },
+		},
+	},
+	flows: {
+		simple: {
+			description: "A simple flow",
+			steps: [{ goto: "https://example.com" }],
+		},
+	},
+};
+
+describe("handleFlow --webhook validation", () => {
+	test("returns error when --webhook has no value", async () => {
+		const result = await handleFlow(BASE_CONFIG, null as any, [
+			"simple",
+			"--webhook",
+		]);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("Missing value for --webhook");
+		}
+	});
+});
+
+describe("parseHealthcheckArgs --webhook", () => {
+	test("parses --webhook URL", () => {
+		const result = parseHealthcheckArgs([
+			"--webhook",
+			"https://hooks.example.com/test",
+		]);
+		expect(result.webhookUrl).toBe("https://hooks.example.com/test");
+		expect(result.error).toBeUndefined();
+	});
+
+	test("returns error when --webhook has no value", () => {
+		const result = parseHealthcheckArgs(["--webhook"]);
+		expect(result.error).toContain("Missing value for --webhook");
+	});
+});


### PR DESCRIPTION
## Summary

Adds a `--webhook <url>` flag to `browse flow` and `browse healthcheck` commands that POSTs a JSON result payload to the given URL on completion.

- New `src/webhook.ts` module with payload formatters and fire-and-forget `sendWebhook()` utility
- `--webhook` flag registered in KNOWN_FLAGS and parsed in both flow and healthcheck commands
- Webhook is non-blocking — network errors are silently ignored so they never affect command output
- 16 new tests covering flag parsing, payload formatting, HTTP behaviour, and integration

### Webhook payload shape

```json
{
  "type": "flow",
  "name": "smoke-test",
  "status": "passed",
  "summary": { "total": 5, "passed": 5, "failed": 0 },
  "duration_ms": 1234,
  "failures": [],
  "timestamp": "2026-03-19T12:00:00.000Z"
}
```

### Use cases

- Slack/Teams notifications on QA failure
- PagerDuty alerts for healthcheck regressions
- CI/CD pipeline callbacks
- External dashboards and monitoring

Closes #82

## Test plan

- [x] `parseWebhookFlag` extracts URL, returns undefined when absent, errors on missing value
- [x] `formatFlowWebhookPayload` produces correct payload for passing and failing flows
- [x] `formatHealthcheckWebhookPayload` produces correct payload for passing and failing healthchecks
- [x] `sendWebhook` calls fetch with correct method/headers/body
- [x] `sendWebhook` swallows fetch errors and non-2xx responses
- [x] Integration: `handleFlow` returns error for `--webhook` with no value
- [x] Integration: `parseHealthcheckArgs` parses `--webhook` URL
- [x] Full test suite (896 tests) passes with no regressions
- [x] `bun run check:fix` passes