### PR TITLE
fix: use --user-agent= Chromium flag to patch ServiceWorker UA leak

### DIFF
--- a/extensions/stealth-worker-fix/fix.js
+++ b/extensions/stealth-worker-fix/fix.js
@@ -6,6 +6,7 @@
 // 1. Navigator.prototype.userAgent — removes HeadlessChrome
 // 2. Navigator.prototype.userAgentData — consistent brands/versions
 // 3. SharedWorker constructor — wraps with UA patches for worker contexts
+// ServiceWorker UA is handled by --user-agent= Chromium flag (stealth.ts).
 //
 // Property descriptors use native-style getters with individually
 // spoofed toString methods to avoid global Function.prototype.toString
@@ -115,7 +116,11 @@
 		});
 	}
 
-	// --- 3. Worker interception (SharedWorker + ServiceWorker) ---
+	// --- 3. SharedWorker interception ---
+	// Note: ServiceWorker UA is handled by the --user-agent= Chromium flag
+	// at the browser process level (see stealthArgs in stealth.ts).
+	// Blob URLs cannot register ServiceWorkers, so JS-level interception
+	// is not viable for SW contexts.
 
 	// Build self-contained patch code for injection into worker contexts
 	var workerPatchCode = [
@@ -191,64 +196,8 @@
 	});
 
 	window.SharedWorker = PatchedSharedWorker;
-	} // end SharedWorker
-
-	// --- 4. ServiceWorker interception ---
-	// Intercept navigator.serviceWorker.register() to wrap SW scripts
-	// with navigator patches via a blob URL + importScripts.
-	if (navigator.serviceWorker) {
-		var origRegister = ServiceWorkerContainer.prototype.register;
-		var patchedRegister = makeNativeFunction(
-			"register",
-			function register(scriptURL, options) {
-				var resolvedURL;
-				try {
-					resolvedURL = new URL(scriptURL, location.href).href;
-				} catch (_) {
-					return origRegister.call(this, scriptURL, options);
-				}
-
-				// SW scripts always use importScripts (no ES module support in
-				// most SW contexts), but respect type: "module" if specified.
-				var wrapperCode;
-				if (options && options.type === "module") {
-					wrapperCode =
-						workerPatchCode +
-						"\nimport " +
-						JSON.stringify(resolvedURL) +
-						";";
-				} else {
-					wrapperCode =
-						workerPatchCode +
-						"\nimportScripts(" +
-						JSON.stringify(resolvedURL) +
-						");";
-				}
-
-				var blob = new Blob([wrapperCode], {
-					type: "application/javascript",
-				});
-				var blobURL = URL.createObjectURL(blob);
-
-				// SW registration requires a scope — preserve the original
-				// script's directory as default scope if not explicitly set.
-				var newOpts = Object.assign({}, options || {});
-				if (!newOpts.scope) {
-					// Default scope is the directory of the original script
-					var lastSlash = resolvedURL.lastIndexOf("/");
-					if (lastSlash !== -1) {
-						newOpts.scope = resolvedURL.substring(0, lastSlash + 1);
-					}
-				}
-
-				return origRegister.call(this, blobURL, newOpts).finally(
-					() => {
-						URL.revokeObjectURL(blobURL);
-					},
-				);
-			},
-		);
-
-		ServiceWorkerContainer.prototype.register = patchedRegister;
+	} catch (_) {
+		// SharedWorker may not be available in all contexts
+	}
 	}
 })();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1219,7 +1219,7 @@ export async function startDaemon(
 	if (isChromium) {
 		stealthOpts = await buildStealthUA("chrome");
 		launchOptions.channel = "chrome";
-		launchOptions.args = stealthArgs();
+		launchOptions.args = stealthArgs(stealthOpts.userAgent);
 		launchOptions.ignoreDefaultArgs = ["--enable-automation"];
 		launchOptions.userAgent = stealthOpts.userAgent;
 	}
@@ -1235,9 +1235,10 @@ export async function startDaemon(
 		await applyStealthScripts(context, opts);
 
 		// Also use CDP Emulation.setUserAgentOverride per page.
-		// The launch-level userAgent only sets HTTP headers.
-		// CDP override patches navigator.userAgent in JS for dedicated workers.
-		// (SharedWorkers/ServiceWorkers require the extension's constructor wrapper.)
+		// The launch-level userAgent only sets HTTP headers; CDP override
+		// patches navigator.userAgent in JS for dedicated workers.
+		// ServiceWorkers are covered by the --user-agent= Chromium flag
+		// passed via stealthArgs().
 		const applyUAOverride = async (p: Page) => {
 			try {
 				const cdp = await context.newCDPSession(p);

--- a/src/stealth.ts
+++ b/src/stealth.ts
@@ -311,8 +311,16 @@ function resolveExtensionDir(name: string): string | null {
  * - screenxy-fix: patches CDP mouse coordinate leak in cross-origin iframes
  * - stealth-worker-fix: patches SharedWorker/ServiceWorker UA leak
  */
-export function stealthArgs(): string[] {
+export function stealthArgs(userAgent?: string): string[] {
 	const args: string[] = [];
+
+	// Set UA at the Chromium process level so ALL contexts — including
+	// ServiceWorkers and SharedWorkers — see the clean UA string.
+	// This is distinct from Playwright's userAgent option (HTTP headers only)
+	// and CDP Emulation.setUserAgentOverride (page/dedicated workers only).
+	if (userAgent) {
+		args.push(`--user-agent=${userAgent}`);
+	}
 
 	const extNames = ["screenxy-fix", "stealth-worker-fix"];
 	const extDirs: string[] = [];

--- a/test/stealth.test.ts
+++ b/test/stealth.test.ts
@@ -15,6 +15,19 @@ describe("stealthArgs", () => {
 			expect(extArg).toContain("stealth-worker-fix");
 		}
 	});
+
+	test("includes --user-agent flag when UA is provided", () => {
+		const ua =
+			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/146.0.0.0 Safari/537.36";
+		const args = stealthArgs(ua);
+		expect(args).toContain(`--user-agent=${ua}`);
+	});
+
+	test("omits --user-agent flag when no UA is provided", () => {
+		const args = stealthArgs();
+		const uaArg = args.find((a) => a.startsWith("--user-agent="));
+		expect(uaArg).toBeUndefined();
+	});
 });
 
 describe("applyStealthScripts", () => {


### PR DESCRIPTION
## Summary

- Pass `--user-agent=` as a Chromium launch flag via `stealthArgs()`, which overrides `navigator.userAgent` at the browser process level for **all contexts** including ServiceWorkers — unlike Playwright's `userAgent` option (HTTP headers only) or CDP `Emulation.setUserAgentOverride` (page/dedicated workers only)
- Remove the broken ServiceWorker `register()` blob-URL interception from the extension — blob URLs cannot register ServiceWorkers due to same-origin requirements, and the extension doesn't load in headless mode anyway
- Keep SharedWorker interception intact (works in headed mode)

## Test plan

- [x] New unit tests for `stealthArgs()` with/without UA parameter
- [x] All 1131 existing tests pass
- [x] Binary builds successfully
- [ ] Manual verification: run `browse` against CreepJS and check ServiceWorker UA no longer shows `HeadlessChrome`

Closes #116