### PR TITLE
docs: update stealth documentation to reflect extension-based architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,17 +109,28 @@ Each connection handles exactly one request: connect, send, receive, close.
 
 ## Stealth Mode
 
-Browse uses patchright (a Playwright fork) to reduce automation detection. A random desktop Chrome user-agent matching the host OS is selected via the `user-agents` package.
+Browse uses patchright (a Playwright fork) to reduce automation detection. A deterministic user-agent string is constructed from the installed Chrome version and host OS — no external UA generation dependency.
 
-Patches applied via `addInitScript`:
+Stealth is applied through three complementary layers:
 
-- `navigator.webdriver` set to `false` (on the prototype to avoid detection)
-- `navigator.userAgentData` brands spoofed to match the UA version
-- `navigator.userAgent` overridden
+### 1. Chromium launch arguments (`stealthArgs()`)
 
-Launch arguments include `--disable-blink-features=AutomationControlled` and `--disable-extensions-except` for the screenxy-fix extension.
+- `--disable-blink-features=AutomationControlled` — prevents the engine from setting `navigator.webdriver = true` at the C++ level across all execution contexts (main, workers, iframes)
+- `--user-agent=<ua>` — sets the UA at the Chromium process level so all contexts (including ServiceWorkers) see the clean string
+- Suppression of Playwright-default automation flags (`--disable-popup-blocking`, `--disable-component-update`, `--disable-default-apps`) via `ignoreDefaultArgs`
 
-The **screenxy-fix Chrome extension** patches a CDP mouse coordinate leak in cross-origin iframes (notably Cloudflare Turnstile).
+### 2. Chrome extensions (`extensions/`)
+
+- **stealth-worker-fix** — patches `navigator.userAgent`, `navigator.userAgentData`, `navigator.webdriver`, and `SharedWorker` constructor in all browsing contexts including workers. Uses `this instanceof` checks on prototype getters to throw `TypeError("Illegal invocation")` like native getters (evading CreepJS lie detection). Removes Playwright globals (`__pwInitScripts`, `__playwright__binding__`). Stubs `chrome.app` with native-looking methods. Sets `NavigatorUAData.prototype` on the faked `userAgentData` object so `instanceof` checks pass. Passes through real high-entropy values (`platformVersion`, `architecture`, `bitness`) from the host OS rather than hardcoded defaults.
+- **screenxy-fix** — patches a CDP mouse coordinate leak in cross-origin iframes (notably Cloudflare Turnstile).
+
+### 3. `addInitScript` fallback (`applyStealthScripts()`)
+
+Applies the same navigator patches as the extension, used for isolated (non-persistent) session contexts where the extension content script doesn't load.
+
+### Per-page CDP patching
+
+Each new page gets `Emulation.setUserAgentOverride` via CDP to patch `navigator.userAgent` in dedicated worker contexts where neither the extension nor `addInitScript` can reach.
 
 Stealth options are propagated to isolated session contexts.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -150,7 +150,7 @@ bun run build
 
 Build compiles `src/cli.ts` into a self-contained binary at `dist/browse` using `bun build --compile`. External dependencies (`electron`, `chromium-bidi`) are excluded.
 
-The setup.sh script also copies the `extensions/screenxy-fix` Chrome extension alongside the binary.
+The setup.sh script also copies the Chrome extensions (`extensions/screenxy-fix`, `extensions/stealth-worker-fix`) alongside the binary.
 
 **Important**: Rebuilding does not restart a running daemon. Run `browse quit` first so the next call cold-starts with the new binary.
 
@@ -188,7 +188,6 @@ The setup.sh script also copies the `extensions/screenxy-fix` Chrome extension a
 |---------|---------|
 | `playwright` (patchright@1.58.2) | Browser automation (Chromium) — patched fork for stealth |
 | `@axe-core/playwright` | Accessibility auditing |
-| `user-agents` | Random desktop Chrome UA string generation |
 | `@biomejs/biome` | Linting and formatting |
 | `lefthook` | Git hooks |
 

--- a/docs/why-browse.md
+++ b/docs/why-browse.md
@@ -67,7 +67,7 @@ browse network --all                      # full request/response log
 browse intercept add '**' --status 500    # test error handling
 ```
 
-Browse's stealth mode (via Patchright) includes anti-detection patches — `navigator.webdriver` spoofing, random user agents, headless detection bypass — for authorized penetration testing against bot-protected targets.
+Browse's stealth mode (via Patchright) includes multi-layered anti-detection — Chromium launch flags, a Chrome extension for worker/iframe context patching, and native-looking navigator property overrides — for authorised penetration testing against bot-protected targets.
 
 ## For Accessibility Specialists
 


### PR DESCRIPTION
## Summary

- **`docs/architecture.md`** — Rewrote the Stealth Mode section to document all three layers: Chromium launch args, Chrome extensions (`stealth-worker-fix`, `screenxy-fix`), and `addInitScript` fallback, plus per-page CDP patching
- **`docs/development.md`** — Updated setup.sh reference to mention both extensions; removed `user-agents` from the dependency table (removed in #119)
- **`docs/why-browse.md`** — Updated stealth description from "random user agents" to the current multi-layered approach

Catches up documentation after PRs #119–#124.

## Test plan

- [ ] Review docs for accuracy against current `src/stealth.ts` and `extensions/stealth-worker-fix/fix.js`