### PR TITLE
fix: remove global Function.prototype.toString stealth override

### DIFF
--- a/extensions/stealth-worker-fix/fix.js
+++ b/extensions/stealth-worker-fix/fix.js
@@ -12,9 +12,8 @@
 // Note: navigator.webdriver is handled entirely by --disable-blink-features=AutomationControlled
 // ServiceWorker UA is handled by --user-agent= Chromium flag (stealth.ts).
 //
-// Property descriptors use native-style getters with individually
-// spoofed toString methods to avoid global Function.prototype.toString
-// override which CreepJS detects across all prototype properties.
+// Property descriptors use native-style getters without monkey-patching
+// Function.prototype.toString, which CreepJS can detect across realms.
 (() => {
 	try { window.__stealthExtensionStarted = true; } catch (_) {}
 	// Read the current UA. If CDP Emulation.setUserAgentOverride has already
@@ -35,18 +34,6 @@
 				? "Windows"
 				: "Linux";
 
-	// WeakMap-based toString spoofing — no own properties on functions,
-	// so hasOwnProperty('toString') returns false (matching native).
-	var toStringMap = new WeakMap();
-	var originalToString = Function.prototype.toString;
-	var patchedToString = function toString() {
-		var spoofed = toStringMap.get(this);
-		if (spoofed !== undefined) return spoofed;
-		return originalToString.call(this);
-	};
-	toStringMap.set(patchedToString, "function toString() { [native code] }");
-	Function.prototype.toString = patchedToString;
-
 	function makeNativeGetter(name, proto, valueFn) {
 		var getter = function () {
 			// Reject non-objects (primitives, null, undefined)
@@ -63,12 +50,11 @@
 			}
 			throw new TypeError("Illegal invocation");
 		};
-		toStringMap.set(getter, "function get " + name + "() { [native code] }");
 		return getter;
 	}
 
 	function makeNativeFunction(name, fn) {
-		toStringMap.set(fn, "function " + name + "() { [native code] }");
+		void name;
 		return fn;
 	}
 
@@ -379,7 +365,6 @@
 				}
 			});
 		};
-		toStringMap.set(window.getComputedStyle, "function getComputedStyle() { [native code] }");
 	} catch (e) {
 		window.__getComputedStylePatchError = e.message;
 	}

--- a/src/commands/goto.ts
+++ b/src/commands/goto.ts
@@ -136,20 +136,6 @@ export async function handleGoto(
 				if ((window as Record<string, unknown>).__stealthGotoInjected) return;
 				(window as Record<string, unknown>).__stealthGotoInjected = true;
 
-				// WeakMap-based toString spoofing
-				const toStringMap = new WeakMap<(...args: never) => unknown, string>();
-				const originalToString = Function.prototype.toString;
-				const patchedToString = function toStringPatch(this: unknown) {
-					const spoofed = toStringMap.get(this as () => unknown);
-					if (spoofed !== undefined) return spoofed;
-					return originalToString.call(this);
-				};
-				toStringMap.set(
-					patchedToString,
-					"function toString() { [native code] }",
-				);
-				Function.prototype.toString = patchedToString;
-
 				// Override getComputedStyle to fix ActiveText
 				const originalGetComputedStyle = window.getComputedStyle;
 				window.getComputedStyle = function getComputedStyle(
@@ -176,10 +162,6 @@ export async function handleGoto(
 					}
 					return style;
 				};
-				toStringMap.set(
-					window.getComputedStyle,
-					"function getComputedStyle() { [native code] }",
-				);
 			});
 		} catch {
 			// Injection may fail on some pages (e.g., about:blank)

--- a/src/stealth.ts
+++ b/src/stealth.ts
@@ -167,8 +167,8 @@ export type StealthOpts = {
  * This is a fallback for non-persistent contexts (isolated sessions).
  * The primary patching is done by the stealth-worker-fix extension.
  *
- * Uses per-function toString spoofing (not a global override) to avoid
- * CreepJS detecting modifications across all prototype properties.
+ * Avoids Function.prototype.toString monkey-patching, which creates a
+ * detectable cross-realm signal on CreepJS.
  */
 export async function applyStealthScripts(
 	context: BrowserContext,
@@ -184,27 +184,12 @@ export async function applyStealthScripts(
 			architecture,
 			bitness,
 		}) => {
-			// WeakMap-based toString spoofing — no own properties on functions,
-			// so hasOwnProperty('toString') returns false (matching native).
-			// biome-ignore lint/complexity/noBannedTypes: WeakMap key must be Function
-			const toStringMap = new WeakMap<Function, string>();
-			const originalToString = Function.prototype.toString;
-			// biome-ignore lint/suspicious/noShadowRestrictedNames: must match native Function.prototype.toString name
-			const patchedToString = function toString(
-				this: (...args: unknown[]) => unknown,
-			): string {
-				const spoofed = toStringMap.get(this);
-				if (spoofed !== undefined) return spoofed;
-				return originalToString.call(this);
-			};
-			toStringMap.set(patchedToString, "function toString() { [native code] }");
-			Function.prototype.toString = patchedToString;
-
 			function makeNativeGetter(
 				name: string,
 				proto: object,
 				valueFn: () => unknown,
 			): () => unknown {
+				void name;
 				const getter = function (this: unknown) {
 					// Reject non-objects (primitives, null, undefined)
 					if (
@@ -223,7 +208,6 @@ export async function applyStealthScripts(
 					}
 					throw new TypeError("Illegal invocation");
 				};
-				toStringMap.set(getter, `function get ${name}() { [native code] }`);
 				return getter;
 			}
 
@@ -231,7 +215,7 @@ export async function applyStealthScripts(
 				// biome-ignore lint/complexity/noBannedTypes: generic bound for callable values
 				T extends Function,
 			>(name: string, fn: T): T {
-				toStringMap.set(fn, `function ${name}() { [native code] }`);
+				void name;
 				return fn;
 			}
 
@@ -382,7 +366,7 @@ export async function applyStealthScripts(
 				if (!("setUninstallURL" in runtime))
 					runtime.setUninstallURL = makeNativeFunction(
 						"setUninstallURL",
-						function setUninstallURL(url: string, callback: () => void) {
+						function setUninstallURL(_url: string, callback: () => void) {
 							if (callback) callback();
 							return Promise.resolve();
 						},
@@ -589,11 +573,6 @@ export async function applyStealthScripts(
 					},
 				});
 			};
-			toStringMap.set(
-				window.getComputedStyle,
-				"function getComputedStyle() { [native code] }",
-			);
-
 			// 7. Screen dimensions — headless sets screen to match viewport,
 			// triggering noTaskbar and hasVvpScreenRes. Spoof to a common
 			// monitor resolution and subtract OS chrome.

--- a/test/stealth.test.ts
+++ b/test/stealth.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import {
 	applyStealthScripts,
 	getHighEntropyDefaults,
@@ -104,6 +105,25 @@ describe("applyStealthScripts", () => {
 		// The old approach set own toString on each getter — detectable
 		expect(source).not.toContain("getter.toString =");
 		expect(source).not.toContain("f.toString =");
+	});
+
+	test("init script does not override Function.prototype.toString", async () => {
+		const addInitScript = mock(() => Promise.resolve());
+		const context = { addInitScript } as never;
+
+		await applyStealthScripts(context, {
+			userAgent: "Mozilla/5.0 Chrome/146.0.7680.165",
+			navigatorPlatform: "MacIntel",
+			chromeMajor: "146",
+			chromeFullVersion: "146.0.7680.165",
+			platformVersion: "16.3.0",
+			architecture: "arm",
+			bitness: "64",
+		});
+
+		const [fn] = addInitScript.mock.calls[0];
+		const source = fn.toString();
+		expect(source).not.toContain("Function.prototype.toString =");
 	});
 
 	test("init script includes chrome.runtime stub", async () => {
@@ -245,5 +265,12 @@ describe("applyStealthScripts", () => {
 
 		const [, args] = addInitScript.mock.calls[0];
 		expect(args.chromeFullVersion).toBe("146.0.7680.165");
+	});
+});
+
+describe("stealth worker extension", () => {
+	test("does not override Function.prototype.toString", () => {
+		const source = readFileSync("extensions/stealth-worker-fix/fix.js", "utf8");
+		expect(source).not.toContain("Function.prototype.toString =");
 	});
 });


### PR DESCRIPTION
### Motivation
- Prevent CreepJS cross-realm detection caused by monkey-patching `Function.prototype.toString` which creates a detectable signal across iframes/realms.
- Align implementation and documentation so stealth patches avoid a global `toString` override while still providing prototype getter/function shims.

### Description
- Removed global `Function.prototype.toString` monkey-patch from the init script injected by `applyStealthScripts` (`src/stealth.ts`) and updated related helper functions to avoid relying on a shared `toString` spoof map.
- Removed the same global override from the stealth extension (`extensions/stealth-worker-fix/fix.js`) and adjusted `makeNativeGetter`/`makeNativeFunction` to no-op the previous spoof bookkeeping.
- Removed runtime `toString` override from the `goto` navigation injection (`src/commands/goto.ts`), keeping only the `getComputedStyle` ActiveText mitigation there.
- Added regression tests (`test/stealth.test.ts`) that assert the init-script source and the extension source do not assign to `Function.prototype.toString`.

### Testing
- Ran Biome checks on the modified files with `npx --yes @biomejs/biome check --fix src/stealth.ts src/commands/goto.ts test/stealth.test.ts extensions/stealth-worker-fix/fix.js` which completed successfully for the targeted files.
- Verified statically with a repository grep that no `Function.prototype.toString =` assignments remain in the adjusted paths (no matches found).
- Attempted `bun`-based commands (`bun run check:fix` / `bun test`) but `bun`/`bunx` are not available in this environment, so the project test suite was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac9aea3c8832e8226ed9b19dba725)