### PR TITLE
docs: link roadmap phases to tracking issues

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,23 +54,23 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 
 ### Speed Optimisations
 
-- [ ] **Connection pooling** — Reuse Playwright connections across commands
-- [ ] **Lazy context creation** — Defer browser context creation until needed
-- [ ] **Snapshot caching** — Cache accessibility trees for unchanged pages
-- [ ] **Command batching** — Execute multiple commands in a single daemon round-trip
+- [ ] **Connection pooling** ([#154](https://github.com/forjd/browse/issues/154)) — Reuse Playwright connections across commands
+- [ ] **Lazy context creation** ([#155](https://github.com/forjd/browse/issues/155)) — Defer browser context creation until needed
+- [ ] **Snapshot caching** ([#156](https://github.com/forjd/browse/issues/156)) — Cache accessibility trees for unchanged pages
+- [ ] **Command batching** ([#157](https://github.com/forjd/browse/issues/157)) — Execute multiple commands in a single daemon round-trip
 
 ### Resource Efficiency
 
-- [ ] **Memory optimisation** — Reduce per-page memory footprint
-- [ ] **Disk usage management** — Auto-cleanup of screenshots, traces, videos by retention policy
-- [ ] **Browser tab recycling** — Reuse tabs instead of creating new ones
-- [ ] **Lazy screenshot encoding** — Encode only when needed
+- [ ] **Memory optimisation** ([#158](https://github.com/forjd/browse/issues/158)) — Reduce per-page memory footprint
+- [ ] **Disk usage management** ([#159](https://github.com/forjd/browse/issues/159)) — Auto-cleanup of screenshots, traces, videos by retention policy
+- [ ] **Browser tab recycling** ([#160](https://github.com/forjd/browse/issues/160)) — Reuse tabs instead of creating new ones
+- [ ] **Lazy screenshot encoding** ([#161](https://github.com/forjd/browse/issues/161)) — Encode only when needed
 
 ### Benchmarking
 
-- [ ] **Performance regression suite** — Automated benchmarks on every commit
-- [ ] **Competitive benchmarking** — Compare against Playwright, Selenium, Cypress
-- [ ] **Real-world workload testing** — Typical QA workflows as benchmarks
+- [ ] **Performance regression suite** ([#162](https://github.com/forjd/browse/issues/162)) — Automated benchmarks on every commit
+- [ ] **Competitive benchmarking** ([#163](https://github.com/forjd/browse/issues/163)) — Compare against Playwright, Selenium, Cypress
+- [ ] **Real-world workload testing** ([#164](https://github.com/forjd/browse/issues/164)) — Typical QA workflows as benchmarks
 
 ---
 
@@ -82,21 +82,21 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 
 - [x] **Plugin architecture** — Load external plugins from `~/.browse/plugins/`
 - [x] **Plugin API** — Stable API for adding custom commands and reporters
-- [ ] **Plugin marketplace** — Registry/discovery for community plugins
-- [ ] **Official plugins** — First-party plugins for popular tools (Slack, Discord, JIRA)
+- [ ] **Plugin marketplace** ([#165](https://github.com/forjd/browse/issues/165)) — Registry/discovery for community plugins
+- [ ] **Official plugins** ([#166](https://github.com/forjd/browse/issues/166)) — First-party plugins for popular tools (Slack, Discord, JIRA)
 
 ### Framework Integrations
 
-- [ ] **Jest/Vitest runner** — Native test runner integration
-- [ ] **Cucumber/Gherkin** — BDD-style test definitions
-- [ ] **GitHub Actions** — Official action with built-in caching
-- [ ] **Docker optimisation** — Slimmer container images, multi-stage builds
+- [ ] **Jest/Vitest runner** ([#167](https://github.com/forjd/browse/issues/167)) — Native test runner integration
+- [ ] **Cucumber/Gherkin** ([#168](https://github.com/forjd/browse/issues/168)) — BDD-style test definitions
+- [ ] **GitHub Actions** ([#169](https://github.com/forjd/browse/issues/169)) — Official action with built-in caching
+- [ ] **Docker optimisation** ([#170](https://github.com/forjd/browse/issues/170)) — Slimmer container images, multi-stage builds
 
 ### Output Formats
 
-- [ ] **Additional reporters** — TAP, Allure, HTML with filtering/search
-- [ ] **JUnit enhancements** — Test suite metadata, flaky test detection
-- [ ] **Custom reporter API** — JavaScript/TypeScript reporter plugins
+- [ ] **Additional reporters** ([#171](https://github.com/forjd/browse/issues/171)) — TAP, Allure, HTML with filtering/search
+- [ ] **JUnit enhancements** ([#172](https://github.com/forjd/browse/issues/172)) — Test suite metadata, flaky test detection
+- [ ] **Custom reporter API** ([#173](https://github.com/forjd/browse/issues/173)) — JavaScript/TypeScript reporter plugins
 
 ---
 
@@ -106,24 +106,24 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 
 ### Collaboration
 
-- [ ] **Shared configuration** — Team-wide config with user-specific overrides
-- [ ] **Flow versioning** — Version control integration for flow definitions
-- [ ] **Flow templates** — Pre-built templates for common patterns
-- [ ] **Shared screenshot storage** — S3/GCS/Azure integration for team access
+- [ ] **Shared configuration** ([#174](https://github.com/forjd/browse/issues/174)) — Team-wide config with user-specific overrides
+- [ ] **Flow versioning** ([#175](https://github.com/forjd/browse/issues/175)) — Version control integration for flow definitions
+- [ ] **Flow templates** ([#176](https://github.com/forjd/browse/issues/176)) — Pre-built templates for common patterns
+- [ ] **Shared screenshot storage** ([#177](https://github.com/forjd/browse/issues/177)) — S3/GCS/Azure integration for team access
 
 ### Governance
 
-- [ ] **Audit logging** — Log all commands for compliance (who, what, when)
-- [ ] **Approval workflows** — Require approval for sensitive flows (production)
-- [ ] **Role-based access** — Read-only, operator, admin roles for shared instances
-- [ ] **Secrets management** — Integration with 1Password, HashiCorp Vault, AWS Secrets Manager
+- [ ] **Audit logging** ([#178](https://github.com/forjd/browse/issues/178)) — Log all commands for compliance (who, what, when)
+- [ ] **Approval workflows** ([#179](https://github.com/forjd/browse/issues/179)) — Require approval for sensitive flows (production)
+- [ ] **Role-based access** ([#180](https://github.com/forjd/browse/issues/180)) — Read-only, operator, admin roles for shared instances
+- [ ] **Secrets management** ([#181](https://github.com/forjd/browse/issues/181)) — Integration with 1Password, HashiCorp Vault, AWS Secrets Manager
 
 ### Reporting & Analytics
 
-- [ ] **Historical trends** — Track test performance over time
-- [ ] **Flaky test detection** — Identify unreliable tests automatically
-- [ ] **Coverage reporting** — Page/flow coverage analysis
-- [ ] **Executive dashboards** — High-level health metrics for stakeholders
+- [ ] **Historical trends** ([#182](https://github.com/forjd/browse/issues/182)) — Track test performance over time
+- [ ] **Flaky test detection** ([#183](https://github.com/forjd/browse/issues/183)) — Identify unreliable tests automatically
+- [ ] **Coverage reporting** ([#184](https://github.com/forjd/browse/issues/184)) — Page/flow coverage analysis
+- [ ] **Executive dashboards** ([#185](https://github.com/forjd/browse/issues/185)) — High-level health metrics for stakeholders
 
 ---
 
@@ -133,24 +133,24 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 
 ### Windows Support
 
-- [ ] **Windows daemon** — Named pipes instead of Unix sockets
-- [ ] **Windows installer** — MSI/EXE installer, registry integration
-- [ ] **Windows CI** — GitHub Actions Windows runners
-- [ ] **Path handling** — Cross-platform path normalization
+- [ ] **Windows daemon** ([#186](https://github.com/forjd/browse/issues/186)) — Named pipes instead of Unix sockets
+- [ ] **Windows installer** ([#187](https://github.com/forjd/browse/issues/187)) — MSI/EXE installer, registry integration
+- [ ] **Windows CI** ([#188](https://github.com/forjd/browse/issues/188)) — GitHub Actions Windows runners
+- [ ] **Path handling** ([#189](https://github.com/forjd/browse/issues/189)) — Cross-platform path normalization
 
 ### Cloud Execution
 
-- [ ] **Browserless integration** — Connect to remote Chrome instances
-- [ ] **Lambda/Cloud Functions** — Serverless browser automation
-- [ ] **Grid support** — Selenium Grid-compatible protocol
-- [ ] **Managed cloud** — Hosted browse-as-a-service option
+- [ ] **Browserless integration** ([#190](https://github.com/forjd/browse/issues/190)) — Connect to remote Chrome instances
+- [ ] **Lambda/Cloud Functions** ([#191](https://github.com/forjd/browse/issues/191)) — Serverless browser automation
+- [ ] **Grid support** ([#192](https://github.com/forjd/browse/issues/192)) — Selenium Grid-compatible protocol
+- [ ] **Managed cloud** ([#193](https://github.com/forjd/browse/issues/193)) — Hosted browse-as-a-service option
 
 ### Container Orchestration
 
-- [ ] **Kubernetes operator** — Native K8s integration with CRDs
-- [ ] **Helm charts** — Production-ready deployment templates
-- [ ] **Auto-scaling** — Scale daemon pool based on queue depth
-- [ ] **Health probes** — Liveness/readiness endpoints for K8s
+- [ ] **Kubernetes operator** ([#194](https://github.com/forjd/browse/issues/194)) — Native K8s integration with CRDs
+- [ ] **Helm charts** ([#195](https://github.com/forjd/browse/issues/195)) — Production-ready deployment templates
+- [ ] **Auto-scaling** ([#196](https://github.com/forjd/browse/issues/196)) — Scale daemon pool based on queue depth
+- [ ] **Health probes** ([#197](https://github.com/forjd/browse/issues/197)) — Liveness/readiness endpoints for K8s
 
 ---
 
@@ -160,23 +160,23 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 
 ### Intelligent Automation
 
-- [ ] **Self-healing selectors** — AI-powered selector recovery when elements change
-- [ ] **Visual element detection** — Find elements by description ("the blue submit button")
-- [ ] **Smart waiting** — ML-based wait conditions instead of fixed timeouts
-- [ ] **Anomaly detection** — Flag unusual page changes automatically
+- [ ] **Self-healing selectors** ([#198](https://github.com/forjd/browse/issues/198)) — AI-powered selector recovery when elements change
+- [ ] **Visual element detection** ([#199](https://github.com/forjd/browse/issues/199)) — Find elements by description ("the blue submit button")
+- [ ] **Smart waiting** ([#200](https://github.com/forjd/browse/issues/200)) — ML-based wait conditions instead of fixed timeouts
+- [ ] **Anomaly detection** ([#201](https://github.com/forjd/browse/issues/201)) — Flag unusual page changes automatically
 
 ### Test Generation
 
-- [ ] **Auto-test generation** — Generate test flows from user sessions
-- [ ] **Test case expansion** — Expand manual tests with AI-generated edge cases
-- [ ] **Data generation** — Generate realistic test data for forms
-- [ ] **Visual regression AI** — AI-powered visual diff (ignore dynamic content)
+- [ ] **Auto-test generation** ([#202](https://github.com/forjd/browse/issues/202)) — Generate test flows from user sessions
+- [ ] **Test case expansion** ([#203](https://github.com/forjd/browse/issues/203)) — Expand manual tests with AI-generated edge cases
+- [ ] **Data generation** ([#204](https://github.com/forjd/browse/issues/204)) — Generate realistic test data for forms
+- [ ] **Visual regression AI** ([#205](https://github.com/forjd/browse/issues/205)) — AI-powered visual diff (ignore dynamic content)
 
 ### Documentation
 
-- [ ] **Auto-documentation** — Generate docs from flow definitions
-- [ ] **Video narration** — AI-generated narration for recorded videos
-- [ ] **Bug report generation** — Auto-create detailed bug reports from failures
+- [ ] **Auto-documentation** ([#206](https://github.com/forjd/browse/issues/206)) — Generate docs from flow definitions
+- [ ] **Video narration** ([#207](https://github.com/forjd/browse/issues/207)) — AI-generated narration for recorded videos
+- [ ] **Bug report generation** ([#208](https://github.com/forjd/browse/issues/208)) — Auto-create detailed bug reports from failures
 
 ---
 
@@ -186,24 +186,24 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 
 ### Tooling
 
-- [ ] **VS Code extension** — IntelliSense, debugging, test explorer
-- [ ] **Language server** — Autocomplete for flows and config
-- [ ] **Interactive debugger** — Step-through debugging for flows
-- [ ] **Hot reload** — Auto-restart on config/flow changes
+- [ ] **VS Code extension** ([#209](https://github.com/forjd/browse/issues/209)) — IntelliSense, debugging, test explorer
+- [ ] **Language server** ([#210](https://github.com/forjd/browse/issues/210)) — Autocomplete for flows and config
+- [ ] **Interactive debugger** ([#211](https://github.com/forjd/browse/issues/211)) — Step-through debugging for flows
+- [ ] **Hot reload** ([#212](https://github.com/forjd/browse/issues/212)) — Auto-restart on config/flow changes
 
 ### Debugging
 
-- [ ] **Network inspector** — HAR export, request/response inspection
-- [ ] **Timeline view** — Visual timeline of command execution
-- [ ] **State snapshots** — Full page state capture on failure
-- [ ] **Replay debugging** — Replay failed runs with full observability
+- [ ] **Network inspector** ([#213](https://github.com/forjd/browse/issues/213)) — HAR export, request/response inspection
+- [ ] **Timeline view** ([#214](https://github.com/forjd/browse/issues/214)) — Visual timeline of command execution
+- [ ] **State snapshots** ([#215](https://github.com/forjd/browse/issues/215)) — Full page state capture on failure
+- [ ] **Replay debugging** ([#216](https://github.com/forjd/browse/issues/216)) — Replay failed runs with full observability
 
 ### Onboarding
 
-- [ ] **Interactive tutorial** — Built-in guided tour for new users
-- [ ] **Example library** — Curated examples for common use cases
-- [ ] **Best practices guide** — Patterns for maintainable automation
-- [ ] **Migration guides** — From Selenium, Cypress, Playwright
+- [ ] **Interactive tutorial** ([#217](https://github.com/forjd/browse/issues/217)) — Built-in guided tour for new users
+- [ ] **Example library** ([#218](https://github.com/forjd/browse/issues/218)) — Curated examples for common use cases
+- [ ] **Best practices guide** ([#219](https://github.com/forjd/browse/issues/219)) — Patterns for maintainable automation
+- [ ] **Migration guides** ([#220](https://github.com/forjd/browse/issues/220)) — From Selenium, Cypress, Playwright
 
 ---
 
@@ -213,17 +213,17 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 
 ### Emerging Tech
 
-- [ ] **WebDriver BiDi** — Native BiDi protocol support (when stable)
-- [ ] **WebGPU testing** — GPU-accelerated page testing
-- [ ] **PWA testing** — Service worker, offline, install prompt testing
-- [ ] **WebAssembly inspection** — WASM debugging and testing
+- [ ] **WebDriver BiDi** ([#221](https://github.com/forjd/browse/issues/221)) — Native BiDi protocol support (when stable)
+- [ ] **WebGPU testing** ([#222](https://github.com/forjd/browse/issues/222)) — GPU-accelerated page testing
+- [ ] **PWA testing** ([#223](https://github.com/forjd/browse/issues/223)) — Service worker, offline, install prompt testing
+- [ ] **WebAssembly inspection** ([#224](https://github.com/forjd/browse/issues/224)) — WASM debugging and testing
 
 ### Experimental
 
-- [ ] **Headless vs headed parity** — Ensure identical behaviour in both modes
-- [ ] **Parallel page execution** — True parallelism within a session
-- [ ] **Mobile device farm** — Integration with real device clouds
-- [ ] **AR/VR testing** — WebXR testing capabilities
+- [ ] **Headless vs headed parity** ([#225](https://github.com/forjd/browse/issues/225)) — Ensure identical behaviour in both modes
+- [ ] **Parallel page execution** ([#226](https://github.com/forjd/browse/issues/226)) — True parallelism within a session
+- [ ] **Mobile device farm** ([#227](https://github.com/forjd/browse/issues/227)) — Integration with real device clouds
+- [ ] **AR/VR testing** ([#228](https://github.com/forjd/browse/issues/228)) — WebXR testing capabilities
 
 ---
 


### PR DESCRIPTION
## Summary

- add GitHub issue links for all open roadmap items in Phases 9 through 15
- make the roadmap directly navigable from each backlog item to its tracking issue
- keep the roadmap structure unchanged while wiring in the new issue inventory

## Testing

- bun test