### PR TITLE
feat: expose additional flow reporters

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -94,7 +94,7 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 
 ### Output Formats
 
-- [ ] **Additional reporters** ([#171](https://github.com/forjd/browse/issues/171)) — TAP, Allure, HTML with filtering/search
+- [x] **Additional reporters** ([#171](https://github.com/forjd/browse/issues/171)) — TAP, Allure, HTML with filtering/search
 - [ ] **JUnit enhancements** ([#172](https://github.com/forjd/browse/issues/172)) — Test suite metadata, flaky test detection
 - [ ] **Custom reporter API** ([#173](https://github.com/forjd/browse/issues/173)) — JavaScript/TypeScript reporter plugins
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -731,7 +731,7 @@ List all defined flows. Shows source annotations (`[inline]` or `[file: ...]`) i
 ### flow
 
 ```
-browse flow <name> [--var k=v ...] [--continue-on-error] [--reporter junit] [--dry-run] [--stream] [--webhook <url>]
+browse flow <name> [--var k=v ...] [--continue-on-error] [--reporter <format>] [--dry-run] [--stream] [--webhook <url>]
 ```
 
 Execute a named flow. Flows can be defined inline in `browse.config.json` or as individual JSON files in a `flows/` directory next to the config file. Global flows in `~/.browse/flows/` are also loaded. See [configuration docs](configuration.md#file-based-flows) for details.
@@ -740,7 +740,7 @@ Execute a named flow. Flows can be defined inline in `browse.config.json` or as 
 |------|-------------|
 | `--var k=v` | Pass variables (repeatable) |
 | `--continue-on-error` | Continue executing steps after a failure |
-| `--reporter <format>` | Output format: `junit` (JUnit XML for CI integration) |
+| `--reporter <format>` | Output format: `junit`, `json`, `markdown`, `tap`, `allure`, or `html` |
 | `--dry-run` | Preview steps without executing them |
 | `--stream` | Output real-time NDJSON with one object per step |
 | `--webhook <url>` | POST a JSON result payload to the URL on completion |
@@ -751,6 +751,8 @@ Execute a named flow. Flows can be defined inline in `browse.config.json` or as 
 browse flow login --var user=admin --var pass=secret
 browse flow checkout --continue-on-error
 browse flow smoke-test --reporter junit > results.xml
+browse flow smoke-test --reporter tap
+browse flow smoke-test --reporter html > report.html
 browse flow signup --dry-run
 browse flow smoke-test --stream
 browse flow smoke-test --webhook https://hooks.slack.com/services/T.../B.../xxx
@@ -1563,7 +1565,7 @@ browse assert-ai "page looks correct" --base-url https://openrouter.ai/api/v1 --
 ### test-matrix
 
 ```sh
-browse test-matrix --roles <role1,role2,...> --flow <flow-name> [--env <env>] [--reporter junit]
+browse test-matrix --roles <role1,role2,...> --flow <flow-name> [--env <env>] [--reporter <format>]
 ```
 
 Run the same flow in parallel across multiple roles/environments. Each role gets its own isolated browser context with separate authentication. Compares results across roles and highlights differences.
@@ -1575,7 +1577,7 @@ Roles must correspond to environment names in `browse.config.json`.
 | `--roles <r1,r2,...>` | Comma-separated list of roles (minimum 2) |
 | `--flow <name>` | Flow to execute (from `browse.config.json`) |
 | `--env <name>` | Environment prefix (tries `<env>-<role>` then `<role>`) |
-| `--reporter junit` | Output JUnit XML format |
+| `--reporter <format>` | Output format: `junit`, `json`, `markdown`, `tap`, `allure`, or `html` |
 
 **Examples:**
 
@@ -1583,6 +1585,7 @@ Roles must correspond to environment names in `browse.config.json`.
 browse test-matrix --roles admin,viewer,guest --flow checkout
 browse test-matrix --roles admin,viewer --flow dashboard --env staging
 browse test-matrix --roles admin,viewer --flow dashboard --reporter junit > results.xml
+browse test-matrix --roles admin,viewer --flow dashboard --reporter tap
 ```
 
 ---

--- a/src/commands/flow.ts
+++ b/src/commands/flow.ts
@@ -11,9 +11,10 @@ import {
 } from "../flow-runner.ts";
 import type { Response } from "../protocol.ts";
 import {
-	formatFlowJson,
-	formatFlowJUnit,
-	formatFlowMarkdown,
+	FLOW_REPORTER_NAMES,
+	type FlowReporter,
+	formatFlowReporter,
+	isFlowReporter,
 } from "../reporters.ts";
 import {
 	formatFlowWebhookPayload,
@@ -122,23 +123,23 @@ export async function handleFlow(
 	const stream = args.includes("--stream");
 
 	// Parse reporter flag
-	const VALID_REPORTERS = ["junit", "json", "markdown"];
-	let reporter: string | undefined;
+	let reporter: FlowReporter | undefined;
 	for (let i = 1; i < args.length; i++) {
 		if (args[i] === "--reporter") {
 			if (i + 1 >= args.length || args[i + 1].startsWith("--")) {
 				return {
 					ok: false,
-					error: `Missing value for --reporter. Valid reporters: ${VALID_REPORTERS.join(", ")}`,
+					error: `Missing value for --reporter. Valid reporters: ${FLOW_REPORTER_NAMES}`,
 				};
 			}
-			reporter = args[i + 1];
-			if (!VALID_REPORTERS.includes(reporter)) {
+			const reporterValue = args[i + 1];
+			if (!isFlowReporter(reporterValue)) {
 				return {
 					ok: false,
-					error: `Invalid reporter '${reporter}'. Valid reporters: ${VALID_REPORTERS.join(", ")}`,
+					error: `Invalid reporter '${reporterValue}'. Valid reporters: ${FLOW_REPORTER_NAMES}`,
 				};
 			}
+			reporter = reporterValue;
 			break;
 		}
 	}
@@ -217,17 +218,11 @@ export async function handleFlow(
 			: { ok: false, error: output };
 	}
 
-	if (reporter === "junit") {
-		const junit = formatFlowJUnit(flowName, results, durationMs);
-		return allPassed ? { ok: true, data: junit } : { ok: false, error: junit };
-	}
-	if (reporter === "json") {
-		const json = formatFlowJson(flowName, results, durationMs);
-		return allPassed ? { ok: true, data: json } : { ok: false, error: json };
-	}
-	if (reporter === "markdown") {
-		const md = formatFlowMarkdown(flowName, results, durationMs);
-		return allPassed ? { ok: true, data: md } : { ok: false, error: md };
+	if (reporter) {
+		const output = formatFlowReporter(flowName, results, durationMs, reporter);
+		return allPassed
+			? { ok: true, data: output }
+			: { ok: false, error: output };
 	}
 
 	const report = formatFlowReport(

--- a/src/commands/test-matrix.ts
+++ b/src/commands/test-matrix.ts
@@ -5,9 +5,10 @@ import type { StealthOpts } from "../daemon.ts";
 import { parseVars, runFlow, type StepResult } from "../flow-runner.ts";
 import type { Response } from "../protocol.ts";
 import {
-	formatFlowJson,
-	formatFlowJUnit,
-	formatFlowMarkdown,
+	FLOW_REPORTER_NAMES,
+	type FlowReporter,
+	formatFlowReporter,
+	isFlowReporter,
 } from "../reporters.ts";
 import { applyStealthScripts } from "../stealth.ts";
 import type { ConsoleEntry } from "./console.ts";
@@ -59,7 +60,7 @@ export async function handleTestMatrix(
 	let rolesStr: string | undefined;
 	let flowName: string | undefined;
 	let envName: string | undefined;
-	let reporter: string | undefined;
+	let reporter: FlowReporter | undefined;
 	const vars = parseVars(args);
 
 	for (let i = 0; i < args.length; i++) {
@@ -74,7 +75,20 @@ export async function handleTestMatrix(
 			envName = args[i + 1];
 			i++;
 		} else if (arg === "--reporter") {
-			reporter = args[i + 1];
+			const next = args[i + 1];
+			if (!next || next.startsWith("--")) {
+				return {
+					ok: false,
+					error: `Missing value for --reporter. Valid reporters: ${FLOW_REPORTER_NAMES}`,
+				};
+			}
+			if (!isFlowReporter(next)) {
+				return {
+					ok: false,
+					error: `Invalid reporter '${next}'. Valid reporters: ${FLOW_REPORTER_NAMES}`,
+				};
+			}
+			reporter = next;
 			i++;
 		}
 	}
@@ -83,7 +97,7 @@ export async function handleTestMatrix(
 		return {
 			ok: false,
 			error:
-				"Usage: browse test-matrix --roles <role1,role2,...> --flow <flow-name> [--env <env>] [--reporter junit]\n\nRoles must correspond to environment names in browse.config.json.",
+				"Usage: browse test-matrix --roles <role1,role2,...> --flow <flow-name> [--env <env>] [--reporter <format>]\n\nRoles must correspond to environment names in browse.config.json.",
 		};
 	}
 
@@ -240,7 +254,7 @@ export async function handleTestMatrix(
 	const durationMs = Date.now() - startTime;
 
 	// Reporter output
-	if (reporter === "junit" || reporter === "json" || reporter === "markdown") {
+	if (reporter) {
 		const allResults: StepResult[] = [];
 		for (const rr of roleResults) {
 			for (const r of rr.results) {
@@ -252,20 +266,15 @@ export async function handleTestMatrix(
 		}
 		const matrixName = `test-matrix-${flowName}`;
 		const matrixPassed = allResults.every((r) => r.passed);
-		if (reporter === "junit") {
-			const junit = formatFlowJUnit(matrixName, allResults, durationMs);
-			return matrixPassed
-				? { ok: true, data: junit }
-				: { ok: false, error: junit };
-		}
-		if (reporter === "json") {
-			const json = formatFlowJson(matrixName, allResults, durationMs);
-			return matrixPassed
-				? { ok: true, data: json }
-				: { ok: false, error: json };
-		}
-		const md = formatFlowMarkdown(matrixName, allResults, durationMs);
-		return matrixPassed ? { ok: true, data: md } : { ok: false, error: md };
+		const output = formatFlowReporter(
+			matrixName,
+			allResults,
+			durationMs,
+			reporter,
+		);
+		return matrixPassed
+			? { ok: true, data: output }
+			: { ok: false, error: output };
 	}
 
 	// Format comparison report

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,3 +1,5 @@
+import { FLOW_REPORTER_HELP } from "./reporters.ts";
+
 type CommandHelp = {
 	summary: string;
 	usage: string;
@@ -138,7 +140,7 @@ browse flow <name> [--var k=v ...] [--continue-on-error] [--reporter <format>] [
 Flags:
   --var key=value       Pass variables to flow (repeatable)
   --continue-on-error   Continue running steps even if one fails
-  --reporter <format>   Output format: junit (JUnit XML), json (structured JSON), markdown (human-readable Markdown)
+  --reporter <format>   Output format: ${FLOW_REPORTER_HELP}
   --dry-run             Preview step plan without executing
   --stream              Emit step results as NDJSON as they complete
   --webhook <url>       POST a JSON result payload to the URL on completion
@@ -543,7 +545,7 @@ Flags:
   --roles <roles>      Comma-separated list of role names (required)
   --flow <name>        Flow to run for each role (required)
   --env <env>          Environment prefix (e.g., staging → looks for staging-admin, staging-viewer)
-  --reporter <format>  Output format: junit (JUnit XML), json (structured JSON), markdown (human-readable Markdown)
+  --reporter <format>  Output format: ${FLOW_REPORTER_HELP}
 
 Examples:
   browse test-matrix --roles admin,viewer,guest --flow checkout

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -12,6 +12,45 @@ function escapeXml(str: string): string {
 		.replace(/'/g, "&apos;");
 }
 
+function escapeHtml(str: string): string {
+	return str
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+export const FLOW_REPORTERS = [
+	"junit",
+	"json",
+	"markdown",
+	"tap",
+	"allure",
+	"html",
+] as const;
+
+export type FlowReporter = (typeof FLOW_REPORTERS)[number];
+
+const FLOW_REPORTER_DESCRIPTIONS: Record<FlowReporter, string> = {
+	junit: "JUnit XML",
+	json: "structured JSON",
+	markdown: "human-readable Markdown",
+	tap: "TAP 13",
+	allure: "Allure-compatible JSON",
+	html: "interactive HTML report",
+};
+
+export const FLOW_REPORTER_NAMES = FLOW_REPORTERS.join(", ");
+
+export const FLOW_REPORTER_HELP = FLOW_REPORTERS.map(
+	(reporter) => `${reporter} (${FLOW_REPORTER_DESCRIPTIONS[reporter]})`,
+).join(", ");
+
+export function isFlowReporter(value: string): value is FlowReporter {
+	return FLOW_REPORTERS.includes(value as FlowReporter);
+}
+
 /**
  * Format flow results as JUnit XML.
  */
@@ -304,14 +343,14 @@ export function formatFlowTap(flowName: string, results: StepResult[]): string {
 		`# Flow: ${flowName}`,
 		`1..${results.length}`,
 	];
-	for (const result of results) {
+	for (const [index, result] of results.entries()) {
 		const status = result.passed ? "ok" : "not ok";
 		lines.push(
-			`${status} ${result.stepNum} - Step ${result.stepNum}: ${result.description}`,
+			`${status} ${index + 1} - Step ${result.stepNum}: ${result.description}`,
 		);
 		if (!result.passed && result.error) {
 			lines.push(`  ---`);
-			lines.push(`  message: "${result.error.replace(/"/g, '"')}"`);
+			lines.push(`  message: ${JSON.stringify(result.error)}`);
 			lines.push(`  ...`);
 		}
 	}
@@ -345,24 +384,61 @@ export function formatFlowHtml(
 	const rows = results
 		.map(
 			(result) =>
-				`<tr data-step="${result.stepNum}" data-status="${result.passed ? "passed" : "failed"}"><td>${result.stepNum}</td><td>${result.description}</td><td>${result.passed ? "passed" : "failed"}</td><td>${result.error ?? ""}</td></tr>`,
+				`<tr data-step="${result.stepNum}" data-status="${result.passed ? "passed" : "failed"}"><td>${result.stepNum}</td><td>${escapeHtml(result.description)}</td><td>${result.passed ? "passed" : "failed"}</td><td>${escapeHtml(result.error ?? "")}</td></tr>`,
 		)
 		.join("");
+	const escapedFlowName = escapeHtml(flowName);
 
 	return `<!doctype html>
 <html lang="en">
-<head><meta charset="utf-8"><title>Browse report: ${flowName}</title></head>
+<head><meta charset="utf-8"><title>Browse report: ${escapedFlowName}</title></head>
 <body>
-  <h1>Flow report: ${flowName}</h1>
+  <h1>Flow report: ${escapedFlowName}</h1>
   <p>Duration: ${durationMs}ms</p>
   <label for="flow-search">Filter</label>
-  <input id="flow-search" placeholder="Search steps" />
+  <input id="flow-search" type="search" placeholder="Search steps" />
   <table>
     <thead><tr><th>Step</th><th>Description</th><th>Status</th><th>Error</th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
+  <script>
+    const search = document.getElementById("flow-search");
+    const rows = Array.from(document.querySelectorAll("tbody tr"));
+    search?.addEventListener("input", () => {
+      const query = search.value.trim().toLowerCase();
+      for (const row of rows) {
+        const text = row.textContent?.toLowerCase() ?? "";
+        row.hidden = query.length > 0 && !text.includes(query);
+      }
+    });
+  </script>
 </body>
 </html>`;
+}
+
+export function formatFlowReporter(
+	flowName: string,
+	results: StepResult[],
+	durationMs: number,
+	reporter: FlowReporter,
+): string {
+	switch (reporter) {
+		case "junit":
+			return formatFlowJUnit(flowName, results, durationMs);
+		case "json":
+			return formatFlowJson(flowName, results, durationMs);
+		case "markdown":
+			return formatFlowMarkdown(flowName, results, durationMs);
+		case "tap":
+			return formatFlowTap(flowName, results);
+		case "allure":
+			return formatFlowAllureJson(flowName, results, durationMs);
+		case "html":
+			return formatFlowHtml(flowName, results, durationMs);
+	}
+
+	const exhaustive: never = reporter;
+	return exhaustive;
 }
 
 export function computeFlakySteps(

--- a/test/additional-reporters.test.ts
+++ b/test/additional-reporters.test.ts
@@ -19,6 +19,15 @@ describe("additional reporters", () => {
 		expect(tap).toContain("not ok 2 - Step 2: submit");
 	});
 
+	test("numbers TAP assertions sequentially even when step numbers repeat", () => {
+		const tap = formatFlowTap("matrix", [
+			{ stepNum: 1, description: "[admin] goto", passed: true },
+			{ stepNum: 1, description: "[viewer] goto", passed: true },
+		]);
+		expect(tap).toContain("ok 1 - Step 1: [admin] goto");
+		expect(tap).toContain("ok 2 - Step 1: [viewer] goto");
+	});
+
 	test("formats allure-compatible json", () => {
 		const parsed = JSON.parse(formatFlowAllureJson("smoke", RESULTS, 600));
 		expect(parsed.name).toBe("smoke");
@@ -30,5 +39,6 @@ describe("additional reporters", () => {
 		const html = formatFlowHtml("smoke", RESULTS, 600);
 		expect(html).toContain('data-step="2"');
 		expect(html).toContain('<input id="flow-search"');
+		expect(html).toContain('addEventListener("input"');
 	});
 });

--- a/test/flow.test.ts
+++ b/test/flow.test.ts
@@ -186,6 +186,9 @@ describe("handleFlow — reporter validation", () => {
 			expect(result.error).toContain("json");
 			expect(result.error).toContain("markdown");
 			expect(result.error).toContain("junit");
+			expect(result.error).toContain("tap");
+			expect(result.error).toContain("allure");
+			expect(result.error).toContain("html");
 		}
 	});
 
@@ -299,6 +302,56 @@ describe("handleFlow — running flows", () => {
 		if (result.ok) {
 			expect(result.data).toContain("# Flow: simple");
 			expect(result.data).toContain("1 passed");
+		}
+	});
+
+	test("returns TAP output with --reporter tap", async () => {
+		const page = createMockFlowPage();
+		const deps = createMockDeps();
+		const result = await handleFlow(
+			BASE_CONFIG,
+			page,
+			["simple", "--reporter", "tap"],
+			deps as any,
+		);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toContain("TAP version 13");
+			expect(result.data).toContain("1..1");
+		}
+	});
+
+	test("returns Allure output with --reporter allure", async () => {
+		const page = createMockFlowPage();
+		const deps = createMockDeps();
+		const result = await handleFlow(
+			BASE_CONFIG,
+			page,
+			["simple", "--reporter", "allure"],
+			deps as any,
+		);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			const parsed = JSON.parse(result.data);
+			expect(parsed.name).toBe("simple");
+			expect(parsed.status).toBe("passed");
+			expect(parsed.steps).toHaveLength(1);
+		}
+	});
+
+	test("returns HTML output with --reporter html", async () => {
+		const page = createMockFlowPage();
+		const deps = createMockDeps();
+		const result = await handleFlow(
+			BASE_CONFIG,
+			page,
+			["simple", "--reporter", "html"],
+			deps as any,
+		);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toContain("<!doctype html>");
+			expect(result.data).toContain('id="flow-search"');
 		}
 	});
 

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -80,6 +80,22 @@ describe("formatCommandHelp", () => {
 		expect(help).toContain(COMMANDS.tab.usage);
 	});
 
+	test("documents additional reporters for flow commands", () => {
+		const help = formatCommandHelp("flow");
+		expect(help).not.toBeNull();
+		expect(help).toContain("tap");
+		expect(help).toContain("allure");
+		expect(help).toContain("html");
+	});
+
+	test("documents additional reporters for test-matrix", () => {
+		const help = formatCommandHelp("test-matrix");
+		expect(help).not.toBeNull();
+		expect(help).toContain("tap");
+		expect(help).toContain("allure");
+		expect(help).toContain("html");
+	});
+
 	test("returns help text for the help command itself", () => {
 		const help = formatCommandHelp("help");
 		expect(help).not.toBeNull();

--- a/test/test-matrix.test.ts
+++ b/test/test-matrix.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, mock, test } from "bun:test";
+import { handleTestMatrix } from "../src/commands/test-matrix.ts";
+import type { BrowseConfig } from "../src/config.ts";
+
+const TEST_USER_ENV = "BROWSE_TEST_MATRIX_USER";
+const TEST_PASS_ENV = "BROWSE_TEST_MATRIX_PASS";
+
+const BASE_CONFIG: BrowseConfig = {
+	environments: {
+		admin: {
+			loginUrl: "https://example.com/login",
+			userEnvVar: TEST_USER_ENV,
+			passEnvVar: TEST_PASS_ENV,
+			successCondition: { urlContains: "/dashboard" },
+		},
+		viewer: {
+			loginUrl: "https://example.com/login",
+			userEnvVar: TEST_USER_ENV,
+			passEnvVar: TEST_PASS_ENV,
+			successCondition: { urlContains: "/dashboard" },
+		},
+	},
+	flows: {
+		smoke: {
+			description: "Smoke test",
+			steps: [{ goto: "https://example.com/app" }],
+		},
+	},
+};
+
+function createMockRolePage() {
+	return {
+		goto: mock(async () => null),
+		getByRole: mock(() => ({
+			fill: mock(async () => {}),
+			click: mock(async () => {}),
+			first: () => ({
+				isVisible: mock(async () => true),
+				innerText: mock(async () => ""),
+			}),
+			count: mock(async () => 1),
+		})),
+		waitForURL: mock(async () => null),
+		url: mock(() => "https://example.com/dashboard"),
+		on: mock(() => {}),
+		title: mock(async () => "Dashboard"),
+		evaluate: mock(async () => null),
+		innerText: mock(async () => ""),
+		locator: mock(() => ({
+			first: () => ({
+				isVisible: mock(async () => true),
+				innerText: mock(async () => ""),
+			}),
+			count: mock(async () => 1),
+			innerText: mock(async () => ""),
+		})),
+	} as any;
+}
+
+function createDefaultContext() {
+	const browser = {
+		newContext: mock(async () => {
+			const page = createMockRolePage();
+			return {
+				newPage: mock(async () => page),
+				close: mock(async () => {}),
+			};
+		}),
+	};
+
+	return {
+		browser: () => browser,
+	} as any;
+}
+
+describe("handleTestMatrix reporter support", () => {
+	test("rejects invalid reporter names", async () => {
+		const result = await handleTestMatrix(
+			BASE_CONFIG,
+			null as any,
+			["--roles", "admin,viewer", "--flow", "smoke", "--reporter", "csv"],
+			null as any,
+			null as any,
+			createDefaultContext(),
+		);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("Invalid reporter 'csv'");
+			expect(result.error).toContain("tap");
+			expect(result.error).toContain("allure");
+			expect(result.error).toContain("html");
+		}
+	});
+
+	test("returns TAP output with --reporter tap", async () => {
+		const previousUser = process.env[TEST_USER_ENV];
+		const previousPass = process.env[TEST_PASS_ENV];
+		process.env[TEST_USER_ENV] = "user";
+		process.env[TEST_PASS_ENV] = "pass";
+
+		try {
+			const result = await handleTestMatrix(
+				BASE_CONFIG,
+				null as any,
+				["--roles", "admin,viewer", "--flow", "smoke", "--reporter", "tap"],
+				null as any,
+				null as any,
+				createDefaultContext(),
+			);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.data).toContain("TAP version 13");
+				expect(result.data).toContain("1..2");
+				expect(result.data).toContain("[admin] goto https://example.com/app");
+				expect(result.data).toContain("[viewer] goto https://example.com/app");
+			}
+		} finally {
+			if (previousUser === undefined) {
+				delete process.env[TEST_USER_ENV];
+			} else {
+				process.env[TEST_USER_ENV] = previousUser;
+			}
+
+			if (previousPass === undefined) {
+				delete process.env[TEST_PASS_ENV];
+			} else {
+				process.env[TEST_PASS_ENV] = previousPass;
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- expose `tap`, `allure`, and `html` reporters for `browse flow` and `browse test-matrix`
- centralise flow reporter validation and help text, and make the HTML report searchable while keeping TAP numbering valid for matrix output
- expand tests and docs, and mark roadmap item #171 complete

## Testing
- bun run check:fix
- bun test
- ./setup.sh