### PR TITLE
feat: support plugin-provided flow reporters

### DIFF
--- a/.agents/skills/browse-plugins/SKILL.md
+++ b/.agents/skills/browse-plugins/SKILL.md
@@ -7,7 +7,7 @@ description: "Create plugins for the browse CLI. Use when the user wants to exte
 
 ## What a plugin is
 
-A plugin is a TypeScript or JavaScript file that default-exports a `BrowsePlugin` object. It can add custom commands and hook into the lifecycle of any browse command.
+A plugin is a TypeScript or JavaScript file that default-exports a `BrowsePlugin` object. It can add custom commands, custom flow reporters, and hook into the lifecycle of any browse command.
 
 ## Plugin structure
 
@@ -19,6 +19,7 @@ const plugin: BrowsePlugin = {
   name: "my-plugin",
   version: "1.0.0",
   commands: [/* PluginCommand[] */],
+  reporters: [/* CustomReporter[] */],
   hooks: {/* PluginHooks */},
 };
 
@@ -67,6 +68,21 @@ type PluginHooks = {
   cleanup?: () => Promise<void>;
 };
 ```
+
+### CustomReporter
+
+```typescript
+type CustomReporter = {
+  name: string;
+  render: (ctx: {
+    flowName: string;
+    results: StepResult[];
+    durationMs: number;
+  }) => string;
+};
+```
+
+Custom reporters become available through `browse flow --reporter <name>` and `browse test-matrix --reporter <name>`.
 
 ### Response
 
@@ -136,6 +152,7 @@ Plugins are discovered from two sources:
 ## Key behaviours
 
 - **Command names must be unique** — collisions with built-in commands or other plugins are rejected at load time with a warning.
+- **Reporter names must be unique** — collisions with built-in reporters or other plugin reporters are rejected at load time with a warning.
 - **Errors are isolated** — a throwing handler returns `{ ok: false, error }`, never crashes the daemon. Hook errors are caught similarly.
 - **`sessionState` persists per session** — use it to track state across commands. It resets when the session is closed.
 - **`beforeCommand` can short-circuit** — return a `Response` to prevent the command from running.

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ browse flow list
 browse flow signup --var base_url=https://staging.example.com
 browse flow signup --reporter junit          # JUnit XML output for CI
 browse flow signup --reporter json           # structured JSON output
+browse flow signup --reporter teamcity      # plugin-provided custom reporter
 browse flow signup --dry-run                 # preview steps without running
 browse assert text-contains "Welcome"
 browse assert visible ".dashboard"
@@ -420,6 +421,11 @@ const plugin: BrowsePlugin = {
       data: `Hello, ${ctx.args[0] ?? "world"}!`,
     }),
   }],
+  reporters: [{
+    name: "teamcity",
+    render: ({ flowName, results }) =>
+      `##teamcity[testSuiteFinished name='${flowName}' duration='${results.length}']`,
+  }],
 };
 
 export default plugin;
@@ -433,7 +439,7 @@ Register in `browse.config.json`:
 }
 ```
 
-Plugins can also hook into the command lifecycle (`beforeCommand`, `afterCommand`, `cleanup`) and maintain per-session state. Place personal plugins in `~/.browse/plugins/` for auto-discovery across all projects.
+Plugins can also hook into the command lifecycle (`beforeCommand`, `afterCommand`, `cleanup`), maintain per-session state, and register custom flow reporters that become available via `browse flow --reporter <name>` and `browse test-matrix --reporter <name>`. Place personal plugins in `~/.browse/plugins/` for auto-discovery across all projects.
 
 Discover published plugins from the CLI:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,7 +96,7 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 
 - [x] **Additional reporters** ([#171](https://github.com/forjd/browse/issues/171)) — TAP, Allure, HTML with filtering/search
 - [ ] **JUnit enhancements** ([#172](https://github.com/forjd/browse/issues/172)) — Test suite metadata, flaky test detection
-- [ ] **Custom reporter API** ([#173](https://github.com/forjd/browse/issues/173)) — JavaScript/TypeScript reporter plugins
+- [x] **Custom reporter API** ([#173](https://github.com/forjd/browse/issues/173)) — JavaScript/TypeScript reporter plugins
 
 ---
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -24,6 +24,13 @@ const plugin: BrowsePlugin = {
       },
     },
   ],
+  reporters: [
+    {
+      name: "teamcity",
+      render: ({ flowName, results }) =>
+        `##teamcity[testSuiteFinished name='${flowName}' count='${results.length}']`,
+    },
+  ],
 };
 
 export default plugin;
@@ -54,6 +61,7 @@ type BrowsePlugin = {
   name: string;        // Unique plugin name
   version: string;     // Semver version
   commands?: PluginCommand[];
+  reporters?: CustomReporter[];
   hooks?: PluginHooks;
 };
 ```
@@ -103,6 +111,25 @@ type Response =
   | { ok: true; data: string }
   | { ok: false; error: string };
 ```
+
+### Custom reporters
+
+Plugins can contribute custom flow reporters that are available through `browse flow --reporter <name>` and `browse test-matrix --reporter <name>`.
+
+```typescript
+type CustomReporter = {
+  name: string;  // Must not collide with built-in reporters like junit or json
+  render: (ctx: ReporterRenderContext) => string;
+};
+
+type ReporterRenderContext = {
+  flowName: string;
+  results: StepResult[];
+  durationMs: number;
+};
+```
+
+Reporter names must be unique across all loaded plugins. Collisions with built-in reporters or another plugin reporter are skipped with a warning.
 
 ### Hooks
 

--- a/src/commands/flow.ts
+++ b/src/commands/flow.ts
@@ -1,6 +1,7 @@
 import type { Page } from "playwright";
 import type { RingBuffer } from "../buffers.ts";
 import type { BrowseConfig, ConfigContext } from "../config.ts";
+import type { CustomReporterRegistry } from "../custom-reporter.ts";
 import type { FlowSource } from "../flow-loader.ts";
 import {
 	dryRunFlow,
@@ -11,10 +12,9 @@ import {
 } from "../flow-runner.ts";
 import type { Response } from "../protocol.ts";
 import {
-	FLOW_REPORTER_NAMES,
-	type FlowReporter,
 	formatFlowReporter,
-	isFlowReporter,
+	getFlowReporterNames,
+	isKnownFlowReporter,
 } from "../reporters.ts";
 import {
 	formatFlowWebhookPayload,
@@ -38,6 +38,7 @@ export async function handleFlow(
 	configCtx?: ConfigContext,
 	flowSources?: Map<string, FlowSource>,
 	flowLoadErrors?: string[],
+	customReporters?: CustomReporterRegistry,
 ): Promise<Response> {
 	if (!config) {
 		return {
@@ -123,20 +124,21 @@ export async function handleFlow(
 	const stream = args.includes("--stream");
 
 	// Parse reporter flag
-	let reporter: FlowReporter | undefined;
+	let reporter: string | undefined;
 	for (let i = 1; i < args.length; i++) {
 		if (args[i] === "--reporter") {
+			const reporterNames = getFlowReporterNames(customReporters);
 			if (i + 1 >= args.length || args[i + 1].startsWith("--")) {
 				return {
 					ok: false,
-					error: `Missing value for --reporter. Valid reporters: ${FLOW_REPORTER_NAMES}`,
+					error: `Missing value for --reporter. Valid reporters: ${reporterNames}`,
 				};
 			}
 			const reporterValue = args[i + 1];
-			if (!isFlowReporter(reporterValue)) {
+			if (!isKnownFlowReporter(reporterValue, customReporters)) {
 				return {
 					ok: false,
-					error: `Invalid reporter '${reporterValue}'. Valid reporters: ${FLOW_REPORTER_NAMES}`,
+					error: `Invalid reporter '${reporterValue}'. Valid reporters: ${reporterNames}`,
 				};
 			}
 			reporter = reporterValue;
@@ -219,7 +221,13 @@ export async function handleFlow(
 	}
 
 	if (reporter) {
-		const output = formatFlowReporter(flowName, results, durationMs, reporter);
+		const output = formatFlowReporter(
+			flowName,
+			results,
+			durationMs,
+			reporter,
+			customReporters,
+		);
 		return allPassed
 			? { ok: true, data: output }
 			: { ok: false, error: output };

--- a/src/commands/test-matrix.ts
+++ b/src/commands/test-matrix.ts
@@ -1,14 +1,14 @@
 import type { BrowserContext, Page } from "playwright";
 import { RingBuffer } from "../buffers.ts";
 import type { BrowseConfig, ConfigContext, ProxyConfig } from "../config.ts";
+import type { CustomReporterRegistry } from "../custom-reporter.ts";
 import type { StealthOpts } from "../daemon.ts";
 import { parseVars, runFlow, type StepResult } from "../flow-runner.ts";
 import type { Response } from "../protocol.ts";
 import {
-	FLOW_REPORTER_NAMES,
-	type FlowReporter,
 	formatFlowReporter,
-	isFlowReporter,
+	getFlowReporterNames,
+	isKnownFlowReporter,
 } from "../reporters.ts";
 import { applyStealthScripts } from "../stealth.ts";
 import type { ConsoleEntry } from "./console.ts";
@@ -46,6 +46,7 @@ export async function handleTestMatrix(
 	stealthOpts?: StealthOpts,
 	configCtx?: ConfigContext,
 	proxyConfig?: ProxyConfig,
+	customReporters?: CustomReporterRegistry,
 ): Promise<Response> {
 	if (!config) {
 		return {
@@ -60,7 +61,7 @@ export async function handleTestMatrix(
 	let rolesStr: string | undefined;
 	let flowName: string | undefined;
 	let envName: string | undefined;
-	let reporter: FlowReporter | undefined;
+	let reporter: string | undefined;
 	const vars = parseVars(args);
 
 	for (let i = 0; i < args.length; i++) {
@@ -76,16 +77,17 @@ export async function handleTestMatrix(
 			i++;
 		} else if (arg === "--reporter") {
 			const next = args[i + 1];
+			const reporterNames = getFlowReporterNames(customReporters);
 			if (!next || next.startsWith("--")) {
 				return {
 					ok: false,
-					error: `Missing value for --reporter. Valid reporters: ${FLOW_REPORTER_NAMES}`,
+					error: `Missing value for --reporter. Valid reporters: ${reporterNames}`,
 				};
 			}
-			if (!isFlowReporter(next)) {
+			if (!isKnownFlowReporter(next, customReporters)) {
 				return {
 					ok: false,
-					error: `Invalid reporter '${next}'. Valid reporters: ${FLOW_REPORTER_NAMES}`,
+					error: `Invalid reporter '${next}'. Valid reporters: ${reporterNames}`,
 				};
 			}
 			reporter = next;
@@ -271,6 +273,7 @@ export async function handleTestMatrix(
 			allResults,
 			durationMs,
 			reporter,
+			customReporters,
 		);
 		return matrixPassed
 			? { ok: true, data: output }

--- a/src/custom-reporter.ts
+++ b/src/custom-reporter.ts
@@ -33,6 +33,10 @@ export class CustomReporterRegistry {
 		return this.#reporters.get(name);
 	}
 
+	has(name: string): boolean {
+		return this.#reporters.has(name);
+	}
+
 	list(): string[] {
 		return [...this.#reporters.keys()].sort();
 	}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -104,6 +104,7 @@ import { handleWipe } from "./commands/wipe.ts";
 import { generateCompletions } from "./completions.ts";
 import type { BrowseConfig, BrowserName, ProxyConfig } from "./config.ts";
 import { loadConfig, resolveConfigPath } from "./config.ts";
+import { CustomReporterRegistry } from "./custom-reporter.ts";
 import { checkUnknownFlags, unknownFlagsError } from "./flags.ts";
 import type { FlowSource } from "./flow-loader.ts";
 import {
@@ -595,6 +596,10 @@ export async function startServer(
 	const pluginCommandNames: ReadonlySet<string> = new Set(
 		pluginRegistry.commands.keys(),
 	);
+	const customReporters = new CustomReporterRegistry();
+	for (const { reporter } of pluginRegistry.reporters.values()) {
+		customReporters.register(reporter);
+	}
 
 	/** Resolve which session to use for a request */
 	function resolveSession(sessionName?: string): Session | { error: string } {
@@ -1145,6 +1150,7 @@ export async function startServer(
 								configCtx,
 								flowSources,
 								flowLoadErrors,
+								customReporters,
 							);
 						case "assert":
 							return handleAssert(config, page, request.args);
@@ -1292,6 +1298,7 @@ export async function startServer(
 								stealthOpts,
 								configCtx,
 								proxyConfig,
+								customReporters,
 							);
 						case "assert-ai":
 							return handleAssertAi(page, request.args);

--- a/src/help.ts
+++ b/src/help.ts
@@ -140,7 +140,7 @@ browse flow <name> [--var k=v ...] [--continue-on-error] [--reporter <format>] [
 Flags:
   --var key=value       Pass variables to flow (repeatable)
   --continue-on-error   Continue running steps even if one fails
-  --reporter <format>   Output format: ${FLOW_REPORTER_HELP}
+  --reporter <format>   Output format: ${FLOW_REPORTER_HELP}, or a plugin-provided reporter name
   --dry-run             Preview step plan without executing
   --stream              Emit step results as NDJSON as they complete
   --webhook <url>       POST a JSON result payload to the URL on completion
@@ -559,7 +559,7 @@ Flags:
   --roles <roles>      Comma-separated list of role names (required)
   --flow <name>        Flow to run for each role (required)
   --env <env>          Environment prefix (e.g., staging → looks for staging-admin, staging-viewer)
-  --reporter <format>  Output format: ${FLOW_REPORTER_HELP}
+  --reporter <format>  Output format: ${FLOW_REPORTER_HELP}, or a plugin-provided reporter name
 
 Examples:
   browse test-matrix --roles admin,viewer,guest --flow checkout

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import type { BrowseConfig } from "./config.ts";
+import type { CustomReporter } from "./custom-reporter.ts";
 import type {
 	BrowsePlugin,
 	CommandContext,
@@ -9,10 +10,12 @@ import type {
 	PluginHooks,
 } from "./plugin.ts";
 import type { Response } from "./protocol.ts";
+import { FLOW_REPORTERS } from "./reporters.ts";
 
 export type PluginRegistry = {
 	plugins: Map<string, BrowsePlugin>;
 	commands: Map<string, { plugin: string; command: PluginCommand }>;
+	reporters: Map<string, { plugin: string; reporter: CustomReporter }>;
 	hooks: {
 		beforeCommand: Array<{
 			plugin: string;
@@ -33,6 +36,7 @@ export function createEmptyRegistry(): PluginRegistry {
 	return {
 		plugins: new Map(),
 		commands: new Map(),
+		reporters: new Map(),
 		hooks: {
 			beforeCommand: [],
 			afterCommand: [],
@@ -112,6 +116,20 @@ export function validatePlugin(
 		}
 	}
 
+	if (obj.reporters !== undefined) {
+		if (!Array.isArray(obj.reporters)) {
+			return `Plugin '${obj.name}': 'reporters' must be an array.`;
+		}
+		for (let i = 0; i < obj.reporters.length; i++) {
+			const err = validateCustomReporter(
+				obj.reporters[i],
+				obj.name as string,
+				i,
+			);
+			if (err) return err;
+		}
+	}
+
 	if (obj.hooks !== undefined) {
 		if (typeof obj.hooks !== "object" || obj.hooks === null) {
 			return `Plugin '${obj.name}': 'hooks' must be an object.`;
@@ -161,6 +179,28 @@ function validatePluginCommand(
 		) {
 			return `Plugin '${pluginName}': command '${obj.name}' 'flags' must be a string array.`;
 		}
+	}
+
+	return null;
+}
+
+function validateCustomReporter(
+	reporter: unknown,
+	pluginName: string,
+	index: number,
+): string | null {
+	if (typeof reporter !== "object" || reporter === null) {
+		return `Plugin '${pluginName}': reporter at index ${index} must be an object.`;
+	}
+
+	const obj = reporter as Record<string, unknown>;
+
+	if (typeof obj.name !== "string" || obj.name.length === 0) {
+		return `Plugin '${pluginName}': reporter at index ${index} is missing a 'name' string.`;
+	}
+
+	if (typeof obj.render !== "function") {
+		return `Plugin '${pluginName}': reporter '${obj.name}' is missing a 'render' function.`;
 	}
 
 	return null;
@@ -220,6 +260,35 @@ export async function loadPlugins(
 					registry.commands.set(command.name, {
 						plugin: plugin.name,
 						command,
+					});
+				}
+			}
+
+			// Register custom reporters
+			if (plugin.reporters) {
+				for (const reporter of plugin.reporters) {
+					if (
+						FLOW_REPORTERS.includes(
+							reporter.name as (typeof FLOW_REPORTERS)[number],
+						)
+					) {
+						errors.push(
+							`Plugin '${plugin.name}': reporter '${reporter.name}' conflicts with a built-in reporter — skipped.`,
+						);
+						continue;
+					}
+
+					const existing = registry.reporters.get(reporter.name);
+					if (existing) {
+						errors.push(
+							`Plugin '${plugin.name}': reporter '${reporter.name}' conflicts with plugin '${existing.plugin}' — skipped.`,
+						);
+						continue;
+					}
+
+					registry.reporters.set(reporter.name, {
+						plugin: plugin.name,
+						reporter,
 					});
 				}
 			}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,6 @@
 import type { BrowserContext, Page } from "playwright";
 import type { BrowseConfig } from "./config.ts";
+import type { CustomReporter } from "./custom-reporter.ts";
 import type { Response } from "./protocol.ts";
 
 /** Context bag passed to every plugin command handler. */
@@ -62,6 +63,8 @@ export type BrowsePlugin = {
 	version: string;
 	/** Commands contributed by this plugin. */
 	commands?: PluginCommand[];
+	/** Custom flow reporters contributed by this plugin. */
+	reporters?: CustomReporter[];
 	/** Lifecycle hooks. */
 	hooks?: PluginHooks;
 };

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -1,3 +1,4 @@
+import type { CustomReporterRegistry } from "./custom-reporter.ts";
 import type { StepResult } from "./flow-runner.ts";
 
 /**
@@ -49,6 +50,20 @@ export const FLOW_REPORTER_HELP = FLOW_REPORTERS.map(
 
 export function isFlowReporter(value: string): value is FlowReporter {
 	return FLOW_REPORTERS.includes(value as FlowReporter);
+}
+
+export function getFlowReporterNames(
+	customReporters?: CustomReporterRegistry,
+): string {
+	const customNames = customReporters?.list() ?? [];
+	return [...FLOW_REPORTERS, ...customNames].join(", ");
+}
+
+export function isKnownFlowReporter(
+	value: string,
+	customReporters?: CustomReporterRegistry,
+): boolean {
+	return isFlowReporter(value) || customReporters?.has(value) === true;
 }
 
 /**
@@ -420,25 +435,39 @@ export function formatFlowReporter(
 	flowName: string,
 	results: StepResult[],
 	durationMs: number,
-	reporter: FlowReporter,
+	reporter: string,
+	customReporters?: CustomReporterRegistry,
 ): string {
-	switch (reporter) {
-		case "junit":
-			return formatFlowJUnit(flowName, results, durationMs);
-		case "json":
-			return formatFlowJson(flowName, results, durationMs);
-		case "markdown":
-			return formatFlowMarkdown(flowName, results, durationMs);
-		case "tap":
-			return formatFlowTap(flowName, results);
-		case "allure":
-			return formatFlowAllureJson(flowName, results, durationMs);
-		case "html":
-			return formatFlowHtml(flowName, results, durationMs);
+	if (isFlowReporter(reporter)) {
+		switch (reporter) {
+			case "junit":
+				return formatFlowJUnit(flowName, results, durationMs);
+			case "json":
+				return formatFlowJson(flowName, results, durationMs);
+			case "markdown":
+				return formatFlowMarkdown(flowName, results, durationMs);
+			case "tap":
+				return formatFlowTap(flowName, results);
+			case "allure":
+				return formatFlowAllureJson(flowName, results, durationMs);
+			case "html":
+				return formatFlowHtml(flowName, results, durationMs);
+		}
+
+		const exhaustive: never = reporter;
+		return exhaustive;
 	}
 
-	const exhaustive: never = reporter;
-	return exhaustive;
+	const customReporter = customReporters?.get(reporter);
+	if (customReporter) {
+		return customReporter.render({
+			flowName,
+			results,
+			durationMs,
+		});
+	}
+
+	throw new Error(`Unknown reporter '${reporter}'.`);
 }
 
 export function computeFlakySteps(

--- a/test/flow.test.ts
+++ b/test/flow.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { handleFlow } from "../src/commands/flow.ts";
 import type { BrowseConfig } from "../src/config.ts";
+import { CustomReporterRegistry } from "../src/custom-reporter.ts";
 
 const BASE_CONFIG: BrowseConfig = {
 	environments: {
@@ -287,6 +288,33 @@ describe("handleFlow — running flows", () => {
 			expect(parsed.status).toBe("passed");
 			expect(parsed.steps).toHaveLength(1);
 		}
+	});
+
+	test("returns plugin reporter output with a registered custom reporter", async () => {
+		const page = createMockFlowPage();
+		const deps = createMockDeps();
+		const reporters = new CustomReporterRegistry();
+		reporters.register({
+			name: "teamcity",
+			render: ({ flowName, results }) =>
+				`teamcity:${flowName}:${results.length}`,
+		});
+
+		const result = await handleFlow(
+			BASE_CONFIG,
+			page,
+			["simple", "--reporter", "teamcity"],
+			deps as any,
+			undefined,
+			undefined,
+			undefined,
+			reporters,
+		);
+
+		expect(result).toEqual({
+			ok: true,
+			data: "teamcity:simple:1",
+		});
 	});
 
 	test("returns Markdown output with --reporter markdown", async () => {

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -201,6 +201,32 @@ describe("loadPlugins", () => {
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
+	test("registers plugin-provided custom reporters", async () => {
+		mkdirSync(tmpDir, { recursive: true });
+		const path = writePlugin(
+			"reporter-plugin.ts",
+			`export default {
+				name: "reporters",
+				version: "1.0.0",
+				reporters: [{
+					name: "teamcity",
+					render: ({ flowName }) => ".tc " + flowName,
+				}],
+			};`,
+		);
+
+		const { registry, errors } = await loadPlugins(
+			[path],
+			null,
+			BUILTIN_COMMANDS,
+		);
+
+		expect(errors).toHaveLength(0);
+		expect(registry.reporters.get("teamcity")?.plugin).toBe("reporters");
+
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
 	test("reports error for non-existent file", async () => {
 		const { registry, errors } = await loadPlugins(
 			["/nonexistent/plugin.ts"],
@@ -240,6 +266,34 @@ describe("loadPlugins", () => {
 		expect(registry.commands.has("goto")).toBe(false);
 		// Plugin itself is still registered (only the colliding command is skipped)
 		expect(registry.plugins.has("collider")).toBe(true);
+
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("rejects plugin reporters that collide with built-in reporters", async () => {
+		mkdirSync(tmpDir, { recursive: true });
+		const path = writePlugin(
+			"reporter-collision.ts",
+			`export default {
+				name: "collision",
+				version: "1.0.0",
+				reporters: [{
+					name: "json",
+					render: () => "ignored",
+				}],
+			};`,
+		);
+
+		const { registry, errors } = await loadPlugins(
+			[path],
+			null,
+			BUILTIN_COMMANDS,
+		);
+
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain("conflicts with a built-in reporter");
+		expect(registry.reporters.has("json")).toBe(false);
+		expect(registry.plugins.has("collision")).toBe(true);
 
 		rmSync(tmpDir, { recursive: true, force: true });
 	});

--- a/test/test-matrix.test.ts
+++ b/test/test-matrix.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { handleTestMatrix } from "../src/commands/test-matrix.ts";
 import type { BrowseConfig } from "../src/config.ts";
+import { CustomReporterRegistry } from "../src/custom-reporter.ts";
 
 const TEST_USER_ENV = "BROWSE_TEST_MATRIX_USER";
 const TEST_PASS_ENV = "BROWSE_TEST_MATRIX_PASS";
@@ -116,6 +117,58 @@ describe("handleTestMatrix reporter support", () => {
 				expect(result.data).toContain("[admin] goto https://example.com/app");
 				expect(result.data).toContain("[viewer] goto https://example.com/app");
 			}
+		} finally {
+			if (previousUser === undefined) {
+				delete process.env[TEST_USER_ENV];
+			} else {
+				process.env[TEST_USER_ENV] = previousUser;
+			}
+
+			if (previousPass === undefined) {
+				delete process.env[TEST_PASS_ENV];
+			} else {
+				process.env[TEST_PASS_ENV] = previousPass;
+			}
+		}
+	});
+
+	test("returns plugin reporter output with a registered custom reporter", async () => {
+		const previousUser = process.env[TEST_USER_ENV];
+		const previousPass = process.env[TEST_PASS_ENV];
+		process.env[TEST_USER_ENV] = "user";
+		process.env[TEST_PASS_ENV] = "pass";
+		const reporters = new CustomReporterRegistry();
+		reporters.register({
+			name: "teamcity",
+			render: ({ flowName, results }) =>
+				`teamcity:${flowName}:${results.length}`,
+		});
+
+		try {
+			const result = await handleTestMatrix(
+				BASE_CONFIG,
+				null as any,
+				[
+					"--roles",
+					"admin,viewer",
+					"--flow",
+					"smoke",
+					"--reporter",
+					"teamcity",
+				],
+				null as any,
+				null as any,
+				createDefaultContext(),
+				undefined,
+				undefined,
+				undefined,
+				reporters,
+			);
+
+			expect(result).toEqual({
+				ok: true,
+				data: "teamcity:test-matrix-smoke:2",
+			});
 		} finally {
 			if (previousUser === undefined) {
 				delete process.env[TEST_USER_ENV];


### PR DESCRIPTION
## Summary
- let plugins register custom flow reporters and enforce reporter name validation and collision handling during plugin loading
- wire plugin-provided reporters into `browse flow` and `browse test-matrix`, including dynamic reporter validation and formatting
- document the new reporter plugin API in the README, plugin guide, plugin skill, and roadmap

## Testing
- bun run check:fix
- bun test
- ./setup.sh

Closes #173