### PR TITLE
feat: add official plugin starters

### DIFF
--- a/.agents/skills/browse-plugins/SKILL.md
+++ b/.agents/skills/browse-plugins/SKILL.md
@@ -159,9 +159,17 @@ Plugins are discovered from two sources:
 - **`afterCommand` is read-only** — observe the response but cannot mutate it.
 - **`init` failures are non-fatal** — the plugin's commands and hooks still register.
 
-## Example plugin
+## Example plugins
 
 See `examples/plugin-example.ts` for a working example with a command and lifecycle hooks.
+
+Browse also ships official starter plugins under `examples/plugins/`:
+
+- `examples/plugins/slack/index.ts`
+- `examples/plugins/discord/index.ts`
+- `examples/plugins/jira/index.ts`
+
+Use them as references when building integrations around webhooks or external issue trackers.
 
 ## Full documentation
 

--- a/README.md
+++ b/README.md
@@ -442,13 +442,19 @@ Register in `browse.config.json`:
 
 Plugins can also hook into the command lifecycle (`beforeCommand`, `afterCommand`, `cleanup`), maintain per-session state, and register custom flow reporters that become available via `browse flow --reporter <name>` and `browse test-matrix --reporter <name>`. Place personal plugins in `~/.browse/plugins/` for auto-discovery across all projects.
 
-Discover published plugins from the CLI:
+Discover official starters and community plugins from the CLI:
 
 ```bash
 browse plugins official
 browse plugins search slack
 browse plugins search notifications --limit 10
 ```
+
+Browse also ships official starter plugins for common integrations:
+
+- `./examples/plugins/slack/index.ts`
+- `./examples/plugins/discord/index.ts`
+- `./examples/plugins/jira/index.ts`
 
 See the **[plugin authoring guide](docs/plugins.md)** for full documentation.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -83,7 +83,7 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 - [x] **Plugin architecture** — Load external plugins from `~/.browse/plugins/`
 - [x] **Plugin API** — Stable API for adding custom commands and reporters
 - [x] **Plugin marketplace** ([#165](https://github.com/forjd/browse/issues/165)) — Registry/discovery for community plugins
-- [ ] **Official plugins** ([#166](https://github.com/forjd/browse/issues/166)) — First-party plugins for popular tools (Slack, Discord, JIRA)
+- [x] **Official plugins** ([#166](https://github.com/forjd/browse/issues/166)) — First-party starter plugins for popular tools (Slack, Discord, JIRA)
 
 ### Framework Integrations
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1409,7 +1409,7 @@ browse plugins official
 browse plugins search [query...] [--page <n>] [--limit <n>]
 ```
 
-Discover official Browse plugins and search npm for community plugins tagged with the `browse-plugin` keyword.
+Discover official Browse plugin starters and search npm for community plugins tagged with the `browse-plugin` keyword.
 
 | Flag | Description |
 |------|-------------|

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -181,7 +181,7 @@ Config-declared plugins take precedence on name collision.
 
 ### 3. Marketplace discovery
 
-Browse can also help you discover published plugins before you install them:
+Browse can also help you discover official starters and published community plugins before you install them:
 
 ```bash
 browse plugins official
@@ -189,9 +189,27 @@ browse plugins search slack
 browse plugins search jira --limit 10
 ```
 
-- `browse plugins official` lists first-party plugin packages
+- `browse plugins official` lists first-party plugin starters, including their in-repo source paths
 - `browse plugins search <query>` searches npm for packages tagged with the `browse-plugin` keyword
 - Add the global `--json` flag for machine-readable output
+
+## Official starter plugins
+
+Browse ships first-party starter plugins under `examples/plugins/` for common team integrations:
+
+- `./examples/plugins/slack/index.ts` — send a message to a Slack webhook
+- `./examples/plugins/discord/index.ts` — send a message to a Discord webhook
+- `./examples/plugins/jira/index.ts` — create a JIRA issue for the current page
+
+Register them directly in `browse.config.json` while the standalone packages are being formalised:
+
+```json
+{
+  "plugins": ["./examples/plugins/slack/index.ts"]
+}
+```
+
+Each plugin directory includes its own README with the required environment variables and usage examples.
 
 ## Error handling
 

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,0 +1,19 @@
+# Official Plugin Starters
+
+Browse now ships first-party starter plugins for common team integrations. Each one is a normal browse plugin that you can load directly from this repository while the standalone npm packages are still being formalised.
+
+## Available starters
+
+- `./examples/plugins/slack/index.ts` — post a message to a Slack webhook
+- `./examples/plugins/discord/index.ts` — post a message to a Discord webhook
+- `./examples/plugins/jira/index.ts` — create a JIRA issue for the current page
+
+Register any of them in `browse.config.json`:
+
+```json
+{
+  "plugins": ["./examples/plugins/slack/index.ts"]
+}
+```
+
+See each plugin directory for setup details and environment variables.

--- a/examples/plugins/discord/README.md
+++ b/examples/plugins/discord/README.md
@@ -1,0 +1,24 @@
+# Discord Plugin Starter
+
+Loads a `discord-notify` command that sends a message to a Discord webhook.
+
+## Setup
+
+1. Add the plugin to `browse.config.json`:
+
+```json
+{
+  "plugins": ["./examples/plugins/discord/index.ts"]
+}
+```
+
+2. Set `BROWSE_DISCORD_WEBHOOK_URL` to your Discord webhook URL.
+
+## Usage
+
+```bash
+browse discord-notify
+browse discord-notify "Smoke test passed"
+```
+
+Without a message, the plugin sends the current page URL.

--- a/examples/plugins/discord/index.ts
+++ b/examples/plugins/discord/index.ts
@@ -1,0 +1,71 @@
+import type { BrowsePlugin } from "../../../src/plugin.ts";
+
+function buildDiscordMessage(message: string | undefined, url: string): string {
+	if (message) {
+		return message;
+	}
+
+	return url && url !== "about:blank"
+		? `Browse run update: ${url}`
+		: "Browse run update";
+}
+
+const plugin: BrowsePlugin = {
+	name: "browse-plugin-discord",
+	version: "0.1.0",
+	commands: [
+		{
+			name: "discord-notify",
+			summary: "Send a message to a Discord webhook",
+			usage: `browse discord-notify [message...] [--json]
+
+Environment:
+  BROWSE_DISCORD_WEBHOOK_URL   Discord webhook URL
+
+Examples:
+  browse discord-notify
+  browse discord-notify Deployment finished`,
+			flags: ["--json"],
+			handler: async (ctx) => {
+				const webhookUrl = process.env.BROWSE_DISCORD_WEBHOOK_URL;
+				if (!webhookUrl) {
+					return {
+						ok: false,
+						error:
+							"Set BROWSE_DISCORD_WEBHOOK_URL before using discord-notify.",
+					};
+				}
+
+				const message = buildDiscordMessage(
+					ctx.args.join(" ").trim() || undefined,
+					ctx.page.url(),
+				);
+				const response = await fetch(webhookUrl, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({ content: message }),
+				});
+
+				if (!response.ok) {
+					return {
+						ok: false,
+						error: `Discord webhook failed with status ${response.status}.`,
+					};
+				}
+
+				if (ctx.request.json) {
+					return {
+						ok: true,
+						data: JSON.stringify({ webhookUrl, message }, null, 2),
+					};
+				}
+
+				return { ok: true, data: "Sent Discord notification." };
+			},
+		},
+	],
+};
+
+export default plugin;

--- a/examples/plugins/jira/README.md
+++ b/examples/plugins/jira/README.md
@@ -1,0 +1,30 @@
+# JIRA Plugin Starter
+
+Loads a `jira-create` command that creates a JIRA issue for the current page.
+
+## Setup
+
+1. Add the plugin to `browse.config.json`:
+
+```json
+{
+  "plugins": ["./examples/plugins/jira/index.ts"]
+}
+```
+
+2. Set these environment variables:
+
+- `BROWSE_JIRA_BASE_URL`
+- `BROWSE_JIRA_EMAIL`
+- `BROWSE_JIRA_API_TOKEN`
+- `BROWSE_JIRA_PROJECT_KEY`
+- `BROWSE_JIRA_ISSUE_TYPE` (optional, defaults to `Task`)
+
+## Usage
+
+```bash
+browse jira-create
+browse jira-create "Broken settings page"
+```
+
+Without a summary, the plugin uses the current page URL.

--- a/examples/plugins/jira/index.ts
+++ b/examples/plugins/jira/index.ts
@@ -1,0 +1,127 @@
+import { Buffer } from "node:buffer";
+import type { BrowsePlugin } from "../../../src/plugin.ts";
+
+type JiraConfig = {
+	baseUrl: string;
+	email: string;
+	apiToken: string;
+	projectKey: string;
+	issueType: string;
+};
+
+function readJiraConfig(): JiraConfig | string {
+	const baseUrl = process.env.BROWSE_JIRA_BASE_URL?.replace(/\/$/, "");
+	const email = process.env.BROWSE_JIRA_EMAIL;
+	const apiToken = process.env.BROWSE_JIRA_API_TOKEN;
+	const projectKey = process.env.BROWSE_JIRA_PROJECT_KEY;
+	const issueType = process.env.BROWSE_JIRA_ISSUE_TYPE ?? "Task";
+
+	if (!baseUrl || !email || !apiToken || !projectKey) {
+		return "Set BROWSE_JIRA_BASE_URL, BROWSE_JIRA_EMAIL, BROWSE_JIRA_API_TOKEN, and BROWSE_JIRA_PROJECT_KEY before using jira-create.";
+	}
+
+	return { baseUrl, email, apiToken, projectKey, issueType };
+}
+
+function buildDescription(pageUrl: string) {
+	const lines = ["Created by Browse."];
+	if (pageUrl && pageUrl !== "about:blank") {
+		lines.push(`Current page: ${pageUrl}`);
+	}
+
+	return {
+		type: "doc",
+		version: 1,
+		content: lines.map((line) => ({
+			type: "paragraph",
+			content: [{ type: "text", text: line }],
+		})),
+	};
+}
+
+const plugin: BrowsePlugin = {
+	name: "browse-plugin-jira",
+	version: "0.1.0",
+	commands: [
+		{
+			name: "jira-create",
+			summary: "Create a JIRA issue for the current page",
+			usage: `browse jira-create [summary...] [--json]
+
+Environment:
+  BROWSE_JIRA_BASE_URL      Atlassian site URL
+  BROWSE_JIRA_EMAIL         Atlassian account email
+  BROWSE_JIRA_API_TOKEN     Atlassian API token
+  BROWSE_JIRA_PROJECT_KEY   Project key
+  BROWSE_JIRA_ISSUE_TYPE    Optional issue type (default: Task)
+
+Examples:
+  browse jira-create
+  browse jira-create Broken settings page`,
+			flags: ["--json"],
+			handler: async (ctx) => {
+				const config = readJiraConfig();
+				if (typeof config === "string") {
+					return { ok: false, error: config };
+				}
+
+				const pageUrl = ctx.page.url();
+				const summary =
+					ctx.args.join(" ").trim() ||
+					(pageUrl && pageUrl !== "about:blank"
+						? `Browse issue for ${pageUrl}`
+						: "Browse issue");
+				const response = await fetch(`${config.baseUrl}/rest/api/3/issue`, {
+					method: "POST",
+					headers: {
+						Authorization: `Basic ${Buffer.from(
+							`${config.email}:${config.apiToken}`,
+						).toString("base64")}`,
+						Accept: "application/json",
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({
+						fields: {
+							project: { key: config.projectKey },
+							issuetype: { name: config.issueType },
+							summary,
+							description: buildDescription(pageUrl),
+						},
+					}),
+				});
+
+				if (!response.ok) {
+					return {
+						ok: false,
+						error: `JIRA issue creation failed with status ${response.status}.`,
+					};
+				}
+
+				let body: { key?: string };
+				try {
+					body = (await response.json()) as { key?: string };
+				} catch {
+					return { ok: false, error: "JIRA returned invalid JSON." };
+				}
+
+				if (!body.key) {
+					return {
+						ok: false,
+						error: "JIRA response did not include an issue key.",
+					};
+				}
+
+				if (ctx.request.json) {
+					return {
+						ok: true,
+						data: JSON.stringify({ key: body.key, summary, pageUrl }, null, 2),
+					};
+				}
+
+				return { ok: true, data: `Created JIRA issue ${body.key}.` };
+			},
+		},
+	],
+};
+
+export default plugin;

--- a/examples/plugins/slack/README.md
+++ b/examples/plugins/slack/README.md
@@ -1,0 +1,24 @@
+# Slack Plugin Starter
+
+Loads a `slack-notify` command that sends a message to a Slack incoming webhook.
+
+## Setup
+
+1. Add the plugin to `browse.config.json`:
+
+```json
+{
+  "plugins": ["./examples/plugins/slack/index.ts"]
+}
+```
+
+2. Set `BROWSE_SLACK_WEBHOOK_URL` to your Slack incoming webhook URL.
+
+## Usage
+
+```bash
+browse slack-notify
+browse slack-notify "Smoke test passed"
+```
+
+Without a message, the plugin sends the current page URL.

--- a/examples/plugins/slack/index.ts
+++ b/examples/plugins/slack/index.ts
@@ -1,0 +1,70 @@
+import type { BrowsePlugin } from "../../../src/plugin.ts";
+
+function buildSlackMessage(message: string | undefined, url: string): string {
+	if (message) {
+		return message;
+	}
+
+	return url && url !== "about:blank"
+		? `Browse run update: ${url}`
+		: "Browse run update";
+}
+
+const plugin: BrowsePlugin = {
+	name: "browse-plugin-slack",
+	version: "0.1.0",
+	commands: [
+		{
+			name: "slack-notify",
+			summary: "Send a message to a Slack webhook",
+			usage: `browse slack-notify [message...] [--json]
+
+Environment:
+  BROWSE_SLACK_WEBHOOK_URL   Incoming webhook URL
+
+Examples:
+  browse slack-notify
+  browse slack-notify Deployment finished`,
+			flags: ["--json"],
+			handler: async (ctx) => {
+				const webhookUrl = process.env.BROWSE_SLACK_WEBHOOK_URL;
+				if (!webhookUrl) {
+					return {
+						ok: false,
+						error: "Set BROWSE_SLACK_WEBHOOK_URL before using slack-notify.",
+					};
+				}
+
+				const message = buildSlackMessage(
+					ctx.args.join(" ").trim() || undefined,
+					ctx.page.url(),
+				);
+				const response = await fetch(webhookUrl, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({ text: message }),
+				});
+
+				if (!response.ok) {
+					return {
+						ok: false,
+						error: `Slack webhook failed with status ${response.status}.`,
+					};
+				}
+
+				if (ctx.request.json) {
+					return {
+						ok: true,
+						data: JSON.stringify({ webhookUrl, message }, null, 2),
+					};
+				}
+
+				return { ok: true, data: "Sent Slack notification." };
+			},
+		},
+	],
+};
+
+export default plugin;

--- a/src/official-plugins.ts
+++ b/src/official-plugins.ts
@@ -2,6 +2,7 @@ export type OfficialPlugin = {
 	slug: string;
 	name: string;
 	packageName: string;
+	sourcePath: string;
 	description: string;
 	docsUrl: string;
 };
@@ -11,14 +12,18 @@ export const OFFICIAL_PLUGINS: OfficialPlugin[] = [
 		slug: "slack",
 		name: "Slack Notifications",
 		packageName: "@browse/plugin-slack",
-		description: "Send flow and healthcheck notifications to Slack channels.",
+		sourcePath: "./examples/plugins/slack/index.ts",
+		description:
+			"Send the current page or a custom message to a Slack webhook.",
 		docsUrl: "https://github.com/forjd/browse/tree/main/examples/plugins/slack",
 	},
 	{
 		slug: "discord",
 		name: "Discord Notifications",
 		packageName: "@browse/plugin-discord",
-		description: "Send automation run summaries to Discord webhooks.",
+		sourcePath: "./examples/plugins/discord/index.ts",
+		description:
+			"Send the current page or a custom message to a Discord webhook.",
 		docsUrl:
 			"https://github.com/forjd/browse/tree/main/examples/plugins/discord",
 	},
@@ -26,7 +31,9 @@ export const OFFICIAL_PLUGINS: OfficialPlugin[] = [
 		slug: "jira",
 		name: "JIRA Issue Sync",
 		packageName: "@browse/plugin-jira",
-		description: "Create and update JIRA issues from failed Browse runs.",
+		sourcePath: "./examples/plugins/jira/index.ts",
+		description:
+			"Create a JIRA issue for the current page with Browse context.",
 		docsUrl: "https://github.com/forjd/browse/tree/main/examples/plugins/jira",
 	},
 ];

--- a/src/plugins-command.ts
+++ b/src/plugins-command.ts
@@ -137,6 +137,7 @@ function formatOfficialPlugins(plugins: OfficialPlugin[]): string {
 	for (const plugin of plugins) {
 		lines.push(`${plugin.slug}  ${plugin.packageName}`);
 		lines.push(`  ${plugin.description}`);
+		lines.push(`  Source: ${plugin.sourcePath}`);
 		lines.push(`  Docs: ${plugin.docsUrl}`);
 		lines.push("");
 	}

--- a/test/official-plugin-examples.test.ts
+++ b/test/official-plugin-examples.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { BrowsePlugin, CommandContext } from "../src/plugin.ts";
+import { validatePlugin } from "../src/plugin-loader.ts";
+
+type ExampleModule = {
+	default: BrowsePlugin;
+};
+
+function createContext(url = "https://example.com/dashboard"): CommandContext {
+	return {
+		page: {
+			url: () => url,
+		} as CommandContext["page"],
+		context: {} as CommandContext["context"],
+		config: null,
+		args: [],
+		sessionState: {},
+		request: {},
+	};
+}
+
+describe("official plugin examples", () => {
+	const originalFetch = globalThis.fetch;
+	const originalEnv = { ...process.env };
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		process.env = { ...originalEnv };
+	});
+
+	test("exports valid Browse plugins for Slack, Discord, and JIRA", async () => {
+		const modules = (await Promise.all([
+			import("../examples/plugins/slack/index.ts"),
+			import("../examples/plugins/discord/index.ts"),
+			import("../examples/plugins/jira/index.ts"),
+		])) as ExampleModule[];
+
+		expect(modules.map((module) => module.default.name)).toEqual([
+			"browse-plugin-slack",
+			"browse-plugin-discord",
+			"browse-plugin-jira",
+		]);
+
+		for (const module of modules) {
+			expect(validatePlugin(module.default, "official-plugin-example")).toBe(
+				module.default,
+			);
+		}
+	});
+
+	test("Slack example posts the current page URL to the webhook", async () => {
+		const fetchMock = mock(() => Promise.resolve(new Response("ok")));
+		globalThis.fetch = fetchMock;
+		process.env.BROWSE_SLACK_WEBHOOK_URL =
+			"https://hooks.slack.test/services/123";
+
+		const { default: plugin } = (await import(
+			"../examples/plugins/slack/index.ts"
+		)) as ExampleModule;
+		const result = await plugin.commands?.[0].handler(createContext());
+
+		expect(result).toEqual({
+			ok: true,
+			data: "Sent Slack notification.",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe("https://hooks.slack.test/services/123");
+		expect(JSON.parse(init.body as string)).toEqual({
+			text: "Browse run update: https://example.com/dashboard",
+		});
+	});
+
+	test("Discord example requires its webhook URL", async () => {
+		delete process.env.BROWSE_DISCORD_WEBHOOK_URL;
+
+		const { default: plugin } = (await import(
+			"../examples/plugins/discord/index.ts"
+		)) as ExampleModule;
+		const result = await plugin.commands?.[0].handler(createContext());
+
+		expect(result).toEqual({
+			ok: false,
+			error: "Set BROWSE_DISCORD_WEBHOOK_URL before using discord-notify.",
+		});
+	});
+
+	test("JIRA example creates an issue payload from the current page", async () => {
+		const fetchMock = mock(() =>
+			Promise.resolve(
+				new Response(JSON.stringify({ key: "QA-42" }), { status: 201 }),
+			),
+		);
+		globalThis.fetch = fetchMock;
+		process.env.BROWSE_JIRA_BASE_URL = "https://example.atlassian.net";
+		process.env.BROWSE_JIRA_EMAIL = "qa@example.com";
+		process.env.BROWSE_JIRA_API_TOKEN = "token";
+		process.env.BROWSE_JIRA_PROJECT_KEY = "QA";
+
+		const { default: plugin } = (await import(
+			"../examples/plugins/jira/index.ts"
+		)) as ExampleModule;
+		const result = await plugin.commands?.[0].handler(
+			createContext("https://example.com/settings"),
+		);
+
+		expect(result).toEqual({
+			ok: true,
+			data: "Created JIRA issue QA-42.",
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe("https://example.atlassian.net/rest/api/3/issue");
+		expect(init.method).toBe("POST");
+		expect(init.headers).toMatchObject({
+			Authorization: expect.stringContaining("Basic "),
+			"Content-Type": "application/json",
+		});
+		expect(JSON.parse(init.body as string)).toMatchObject({
+			fields: {
+				project: { key: "QA" },
+				summary: "Browse issue for https://example.com/settings",
+			},
+		});
+	});
+});

--- a/test/official-plugins.test.ts
+++ b/test/official-plugins.test.ts
@@ -15,6 +15,9 @@ describe("official plugins", () => {
 
 	test("finds plugin by slug", () => {
 		expect(findOfficialPlugin("jira")?.packageName).toBe("@browse/plugin-jira");
+		expect(findOfficialPlugin("jira")?.sourcePath).toBe(
+			"./examples/plugins/jira/index.ts",
+		);
 		expect(findOfficialPlugin("unknown")).toBeUndefined();
 	});
 });

--- a/test/plugins-command.test.ts
+++ b/test/plugins-command.test.ts
@@ -11,6 +11,7 @@ describe("plugins command", () => {
 		if (result.ok) {
 			expect(result.data).toContain("@browse/plugin-discord");
 			expect(result.data).toContain("@browse/plugin-jira");
+			expect(result.data).toContain("./examples/plugins/slack/index.ts");
 		}
 	});
 
@@ -23,6 +24,9 @@ describe("plugins command", () => {
 		const parsed = JSON.parse(result.data);
 		expect(parsed.plugins).toHaveLength(3);
 		expect(parsed.plugins[0].slug).toBe("slack");
+		expect(parsed.plugins[0].sourcePath).toBe(
+			"./examples/plugins/slack/index.ts",
+		);
 	});
 
 	test("searches the npm marketplace for community plugins", async () => {


### PR DESCRIPTION
## Summary
- add first-party starter plugins for Slack, Discord, and JIRA under `examples/plugins/`
- expose the starter source paths in `browse plugins official` and cover the new behaviour with tests
- update the roadmap, README, plugin docs, and plugin-authoring skill to point at the shipped starters

Closes #166