### PR TITLE
feat: ship a reusable GitHub Action

### DIFF
--- a/.github/actions/browse/action.yml
+++ b/.github/actions/browse/action.yml
@@ -10,19 +10,57 @@ inputs:
     description: "Path to browse config file"
     required: false
     default: "browse.config.json"
+  bun-version:
+    description: "Bun version to install"
+    required: false
+    default: "latest"
+  browser:
+    description: "Patchright browser channel to install"
+    required: false
+    default: "chrome"
 runs:
   using: "composite"
   steps:
+    - name: Validate runner support
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        echo "Browse GitHub Action currently supports Linux and macOS runners."
+        exit 1
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: latest
-    - name: Install dependencies
+        bun-version: ${{ inputs.bun-version }}
+    - name: Cache Browse runtime
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.bun/install/cache
+          ${{ github.action_path }}/../../../node_modules
+        key: browse-bun-${{ runner.os }}-${{ inputs.bun-version }}-${{ github.action_ref || github.sha }}
+        restore-keys: |
+          browse-bun-${{ runner.os }}-${{ inputs.bun-version }}-
+    - name: Install Browse runtime
+      working-directory: ${{ github.action_path }}/../../..
       shell: bash
       run: bun install --frozen-lockfile
-    - name: Install Playwright browser
+    - name: Cache Playwright browser
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: browse-browser-${{ runner.os }}-${{ inputs.browser }}-${{ github.action_ref || github.sha }}
+        restore-keys: |
+          browse-browser-${{ runner.os }}-${{ inputs.browser }}-
+    - name: Install Playwright browser (Linux)
+      if: runner.os == 'Linux'
+      working-directory: ${{ github.action_path }}/../../..
       shell: bash
-      run: bunx playwright install --with-deps chromium
+      run: bunx patchright install ${{ inputs.browser }} --with-deps
+    - name: Install Playwright browser (macOS)
+      if: runner.os == 'macOS'
+      working-directory: ${{ github.action_path }}/../../..
+      shell: bash
+      run: bunx patchright install ${{ inputs.browser }}
     - name: Run Browse
       shell: bash
-      run: bun run src/cli.ts ${{ inputs.command }} --config ${{ inputs.config }}
+      run: bun run "${{ github.action_path }}/../../../src/cli.ts" ${{ inputs.command }} --config "${{ inputs.config }}"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ browse click @e2
 ## Table of Contents
 
 - [Install](#install)
+- [GitHub Actions](#github-actions)
 - [System Requirements](#system-requirements)
 - [Core Concepts](#core-concepts)
   - [How refs work](#how-refs-work)
@@ -97,6 +98,41 @@ If you use [Claude Code](https://docs.anthropic.com/en/docs/claude-code), instal
 ```bash
 bunx skills add forjd/browse
 ```
+
+---
+
+## GitHub Actions
+
+Use the official composite action to run `browse` in CI with Bun dependencies and Patchright browser binaries cached between runs:
+
+```yaml
+jobs:
+  qa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: forjd/browse/.github/actions/browse@main
+        with:
+          command: healthcheck --reporter junit --out results.xml
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: browse-results
+          path: results.xml
+```
+
+Inputs:
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `command` | `healthcheck` | Browse command to run |
+| `config` | `browse.config.json` | Path to the config file in your repository |
+| `bun-version` | `latest` | Bun version installed by the action |
+| `browser` | `chrome` | Patchright browser channel installed by the action |
+
+The action executes `browse` from the action checkout, but runs it against your repository workspace so relative config paths, flows, and output files still behave normally.
+
+Linux and macOS runners are supported today. Windows support is tracked separately in the platform roadmap.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -89,7 +89,7 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 
 - [ ] **Jest/Vitest runner** ([#167](https://github.com/forjd/browse/issues/167)) — Native test runner integration
 - [ ] **Cucumber/Gherkin** ([#168](https://github.com/forjd/browse/issues/168)) — BDD-style test definitions
-- [ ] **GitHub Actions** ([#169](https://github.com/forjd/browse/issues/169)) — Official action with built-in caching
+- [x] **GitHub Actions** ([#169](https://github.com/forjd/browse/issues/169)) — Official composite action with built-in Bun and Playwright caching
 - [ ] **Docker optimisation** ([#170](https://github.com/forjd/browse/issues/170)) — Slimmer container images, multi-stage builds
 
 ### Output Formats

--- a/test/github-action.test.ts
+++ b/test/github-action.test.ts
@@ -2,10 +2,29 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
 describe("github action", () => {
+	const yaml = readFileSync(".github/actions/browse/action.yml", "utf8");
+
 	test("defines composite action with required command input", () => {
-		const yaml = readFileSync(".github/actions/browse/action.yml", "utf8");
 		expect(yaml).toContain('using: "composite"');
 		expect(yaml).toContain("command:");
 		expect(yaml).toContain("Run Browse");
+	});
+
+	test("installs and runs browse from the action checkout", () => {
+		expect(yaml).toContain("working-directory:");
+		expect(yaml).toContain("github.action_path");
+		expect(yaml).toContain("src/cli.ts");
+	});
+
+	test("caches Bun dependencies and Playwright browsers", () => {
+		expect(yaml).toContain("actions/cache");
+		expect(yaml).toContain("~/.bun/install/cache");
+		expect(yaml).toContain("node_modules");
+		expect(yaml).toContain("~/.cache/ms-playwright");
+	});
+
+	test("fails clearly on unsupported Windows runners", () => {
+		expect(yaml).toContain("runner.os == 'Windows'");
+		expect(yaml).toContain("supports Linux and macOS runners");
 	});
 });


### PR DESCRIPTION
## Summary
- run the official composite action from the action checkout so it works in external repositories instead of assuming the caller repo is this project
- add built-in caches for Bun install state and Playwright browser binaries, plus a clear Windows guard until platform support lands
- document the GitHub Actions workflow in the README and mark roadmap issue #169 complete

## Testing
- bun run check:fix
- bun test
- bun run build

Closes #169