### PR TITLE
feat: optimise Docker image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.agents
+.git
+.github
+.worktrees
+benchmarks
+coverage
+dist
+docs
+examples
+node_modules
+opensrc
+test

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,16 @@
 FROM oven/bun:1 AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile
+COPY patches ./patches
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
 
 FROM deps AS build
 WORKDIR /app
-COPY . .
+COPY src ./src
 RUN bun run build
 
 FROM mcr.microsoft.com/playwright:v1.54.1-noble AS runtime
-WORKDIR /app
+WORKDIR /work
 COPY --from=build /app/dist/browse /usr/local/bin/browse
 ENTRYPOINT ["browse"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ browse click @e2
 
 - [Install](#install)
 - [GitHub Actions](#github-actions)
+- [Docker](#docker)
 - [System Requirements](#system-requirements)
 - [Core Concepts](#core-concepts)
   - [How refs work](#how-refs-work)
@@ -133,6 +134,24 @@ Inputs:
 The action executes `browse` from the action checkout, but runs it against your repository workspace so relative config paths, flows, and output files still behave normally.
 
 Linux and macOS runners are supported today. Windows support is tracked separately in the platform roadmap.
+
+---
+
+## Docker
+
+The repository `Dockerfile` builds a runtime image with `browse`, Bun-built dependencies, and the Playwright system packages already installed.
+
+```bash
+docker build -t browse .
+
+# Run against the current project directory
+docker run --rm -it -v "$PWD":/work -w /work browse healthcheck
+
+# Or use it as a disposable CLI for ad-hoc browser automation
+docker run --rm -it -v "$PWD":/work -w /work browse goto https://example.com
+```
+
+The image uses a multi-stage build, copies only the files needed to compile the binary, and ships with a `.dockerignore` so local docs, tests, and Git metadata do not bloat the build context.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -90,7 +90,7 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 - [ ] **Jest/Vitest runner** ([#167](https://github.com/forjd/browse/issues/167)) — Native test runner integration
 - [ ] **Cucumber/Gherkin** ([#168](https://github.com/forjd/browse/issues/168)) — BDD-style test definitions
 - [x] **GitHub Actions** ([#169](https://github.com/forjd/browse/issues/169)) — Official composite action with built-in Bun and Playwright caching
-- [ ] **Docker optimisation** ([#170](https://github.com/forjd/browse/issues/170)) — Slimmer container images, multi-stage builds
+- [x] **Docker optimisation** ([#170](https://github.com/forjd/browse/issues/170)) — Multi-stage Docker builds now copy only compile inputs, cache Bun installs, and ship with a recommended `.dockerignore`
 
 ### Output Formats
 

--- a/test/dockerfile.test.ts
+++ b/test/dockerfile.test.ts
@@ -8,4 +8,29 @@ describe("docker optimisation", () => {
 		expect(dockerfile).toContain("FROM deps AS build");
 		expect(dockerfile).toContain("FROM mcr.microsoft.com/playwright");
 	});
+
+	test("copies only dependency and build inputs into the image", () => {
+		const dockerfile = readFileSync("Dockerfile", "utf8");
+		expect(dockerfile).toContain("COPY package.json bun.lock ./");
+		expect(dockerfile).toContain("COPY patches ./patches");
+		expect(dockerfile).toContain("COPY src ./src");
+		expect(dockerfile).not.toContain("COPY . .");
+	});
+
+	test("uses a cached Bun install layer", () => {
+		const dockerfile = readFileSync("Dockerfile", "utf8");
+		expect(dockerfile).toContain(
+			"RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile",
+		);
+	});
+
+	test("keeps bulky development paths out of the Docker build context", () => {
+		const dockerignore = readFileSync(".dockerignore", "utf8");
+		expect(dockerignore).toContain(".git");
+		expect(dockerignore).toContain(".worktrees");
+		expect(dockerignore).toContain("docs");
+		expect(dockerignore).toContain("test");
+		expect(dockerignore).toContain("dist");
+		expect(dockerignore).toContain("node_modules");
+	});
 });


### PR DESCRIPTION
## Summary
- copy only the Bun install and compile inputs into the Docker build stages so patched dependencies resolve correctly without shipping the whole repository context
- add a `.dockerignore`, BuildKit cache mount, and a `/work` runtime working directory to make container builds leaner and project mounts easier to use
- document the Docker workflow in the README, expand Docker-focused tests, and mark roadmap issue `#170` complete

## Testing
- bun run check:fix
- bun test
- bun run build
- docker build -t browse:test .
- docker run --rm browse:test --help

Closes #170