### PR TITLE
feat: scaffold built-in flow templates

### DIFF
--- a/.agents/skills/browse/SKILL.md
+++ b/.agents/skills/browse/SKILL.md
@@ -68,7 +68,7 @@ For configured applications, `browse healthcheck` gives a quick pass/fail across
 | **Security** | `security` (headers, cookies, mixed content), `security --json` |
 | **Responsive** | `responsive` (multi-viewport screenshots), `responsive --breakpoints 320x568,1920x1080`, `responsive --url <url>` |
 | **Extract** | `extract table <sel>` (`--csv`, `--json`), `extract links` (`--filter`), `extract meta`, `extract select <sel>` (`--attr`) |
-| **Flows** | `flow list`, `flow <name> --var key=value` (`--reporter junit\|json\|markdown`, `--dry-run`, `--stream`, `--webhook <url>`), `healthcheck` (`--reporter junit\|json\|markdown`, `--parallel`, `--concurrency`, `--webhook <url>`), `test-matrix --roles r1,r2 --flow <name>`, `diff --baseline <url> --current <url>`. Flows can be defined inline in config or as individual JSON files in a `flows/` directory. |
+| **Flows** | `flow list`, `flow init <template> [name] [--force]`, `flow <name> --var key=value` (`--reporter junit\|json\|markdown`, `--dry-run`, `--stream`, `--webhook <url>`), `healthcheck` (`--reporter junit\|json\|markdown`, `--parallel`, `--concurrency`, `--webhook <url>`), `test-matrix --roles r1,r2 --flow <name>`, `diff --baseline <url> --current <url>`. Flows can be defined inline in config or as individual JSON files in a `flows/` directory; `flow init` scaffolds built-in `smoke` and `login-smoke` templates. |
 | **Sessions** | `session list/create/close`, `--session <name>` on any command |
 | **Tracing** | `trace start` (`--screenshots`, `--snapshots`), `trace stop --out <path>`, `trace view [<path>] --latest --port <n>`, `trace list`, `trace status` |
 | **Video** | `video start [--size WxH]`, `video stop [--out <path>]`, `video status`, `video list` |

--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ browse responsive --breakpoints 320x568,768x1024,1920x1080  # custom breakpoints
 Define reusable flows in `browse.config.json` or as individual JSON files in a `flows/` directory, then run them:
 
 ```bash
+browse flow init smoke release-smoke
 browse flow list
 browse flow signup --var base_url=https://staging.example.com
 browse flow signup --reporter junit          # JUnit XML output for CI
@@ -627,6 +628,7 @@ Browse has 90+ commands. Here are the most commonly used:
 | `perf` | Core Web Vitals |
 | `security` | Security audit |
 | `flow <name>` | Run configured flow |
+| `flow init <template>` | Scaffold a built-in flow template |
 | `framework init <runner>` | Scaffold Vitest/Jest Browse tests |
 | `session create <name>` | Create named session |
 | `status` | Daemon status (`--json`, `--watch`, `--exit-code`, `--metrics`) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -108,7 +108,7 @@ The original 6-phase roadmap (Foundation → Snapshot → Screenshot → Auth �
 
 - [ ] **Shared configuration** ([#174](https://github.com/forjd/browse/issues/174)) — Team-wide config with user-specific overrides
 - [ ] **Flow versioning** ([#175](https://github.com/forjd/browse/issues/175)) — Version control integration for flow definitions
-- [ ] **Flow templates** ([#176](https://github.com/forjd/browse/issues/176)) — Pre-built templates for common patterns
+- [x] **Flow templates** ([#176](https://github.com/forjd/browse/issues/176)) — `browse flow init` now scaffolds built-in `smoke` and `login-smoke` starters into `flows/`
 - [ ] **Shared screenshot storage** ([#177](https://github.com/forjd/browse/issues/177)) — S3/GCS/Azure integration for team access
 
 ### Governance

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -728,6 +728,33 @@ browse flow list
 
 List all defined flows. Shows source annotations (`[inline]` or `[file: ...]`) indicating where each flow is defined.
 
+### flow init
+
+```
+browse flow init <template> [name] [--force]
+```
+
+Scaffold a built-in flow template into `flows/` next to the active `browse.config.json`. The generated file is an ordinary flow JSON file that you can edit immediately.
+
+Available templates:
+
+- `smoke` — open a URL and verify expected text
+- `login-smoke` — sign in to an environment and verify a post-login cue
+
+| Argument / Flag | Description |
+|------|-------------|
+| `<template>` | Built-in template name to scaffold |
+| `[name]` | Optional output flow name. Defaults to the template name |
+| `--force` | Overwrite an existing generated flow file |
+
+**Examples:**
+
+```bash
+browse flow init smoke
+browse flow init smoke checkout-smoke
+browse flow init login-smoke admin-login --force
+```
+
 ### flow
 
 ```

--- a/docs/flows-and-healthchecks.md
+++ b/docs/flows-and-healthchecks.md
@@ -64,6 +64,23 @@ Each file contains a bare flow definition — the same shape as what goes inside
 }
 ```
 
+#### Scaffolding from built-in templates
+
+If you want a starting point instead of writing the JSON from scratch, use `browse flow init` to scaffold a built-in template into your local `flows/` directory:
+
+```sh
+browse flow init smoke
+browse flow init smoke checkout-smoke
+browse flow init login-smoke admin-login --force
+```
+
+Built-in templates:
+
+- `smoke` — opens `{{url}}`, asserts `{{expected_text}}`, and captures a screenshot
+- `login-smoke` — wipes session state, logs in with `{{environment}}`, asserts `{{expected_text}}`, and captures a screenshot
+
+The generated files are ordinary flow JSON files, so you can edit descriptions, variables, and steps immediately.
+
 #### Global flows
 
 Flows placed in `~/.browse/flows/` are available across all projects.
@@ -81,6 +98,7 @@ When the same flow name exists in multiple locations, the following precedence a
 ### Running Flows
 
 ```sh
+browse flow init smoke                    # scaffold a starter flow file
 browse flow list                          # list all defined flows
 browse flow signup --var base_url=https://staging.example.com --var test_email=test@example.com
 browse flow signup --var base_url=https://staging.example.com --continue-on-error

--- a/src/commands/flow.ts
+++ b/src/commands/flow.ts
@@ -1,8 +1,11 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
 import type { Page } from "playwright";
 import type { RingBuffer } from "../buffers.ts";
 import type { BrowseConfig, ConfigContext } from "../config.ts";
 import type { CustomReporterRegistry } from "../custom-reporter.ts";
 import type { FlowSource } from "../flow-loader.ts";
+import { isValidFlowName } from "../flow-loader.ts";
 import {
 	dryRunFlow,
 	formatFlowReport,
@@ -10,6 +13,11 @@ import {
 	runFlow,
 	type StepResult,
 } from "../flow-runner.ts";
+import {
+	formatFlowTemplateList,
+	getFlowTemplate,
+	getFlowTemplateNames,
+} from "../flow-templates.ts";
 import type { Response } from "../protocol.ts";
 import {
 	formatFlowReporter,
@@ -31,6 +39,104 @@ export type FlowDeps = {
 	performWipe?: () => Promise<Response>;
 };
 
+const FLOW_INIT_USAGE = `Usage: browse flow init <template> [name] [--force]
+
+Available templates:
+${formatFlowTemplateList()}`;
+
+const FLOW_USAGE = `Usage: browse flow <name> [--var key=value ...] [--continue-on-error] [--reporter <format>] [--junit-property key=value ...] [--dry-run] [--stream] [--webhook <url>]
+browse flow list
+browse flow init <template> [name] [--force]`;
+
+const RESERVED_FLOW_SUBCOMMANDS = new Set(["init", "list"]);
+
+function initFlowFromTemplate(
+	args: string[],
+	configCtx?: ConfigContext,
+): Response {
+	const templateName = args[0];
+	if (!templateName) {
+		return { ok: false, error: FLOW_INIT_USAGE };
+	}
+
+	const template = getFlowTemplate(templateName);
+	if (!template) {
+		return {
+			ok: false,
+			error: `Unknown flow template '${templateName}'. Available: ${getFlowTemplateNames().join(", ")}.`,
+		};
+	}
+
+	let flowName: string | undefined;
+	let force = false;
+	for (let i = 1; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === "--force") {
+			force = true;
+			continue;
+		}
+		if (!flowName) {
+			flowName = arg;
+			continue;
+		}
+		return { ok: false, error: FLOW_INIT_USAGE };
+	}
+
+	const resolvedFlowName = flowName ?? templateName;
+	if (RESERVED_FLOW_SUBCOMMANDS.has(resolvedFlowName)) {
+		return {
+			ok: false,
+			error: `Invalid flow name '${resolvedFlowName}'. 'init' and 'list' are reserved for flow subcommands.`,
+		};
+	}
+	if (!isValidFlowName(resolvedFlowName)) {
+		return {
+			ok: false,
+			error: `Invalid flow name '${resolvedFlowName}'. Use letters, numbers, dots, underscores, or hyphens.`,
+		};
+	}
+
+	if (!configCtx?.configPath) {
+		return {
+			ok: false,
+			error:
+				"No browse.config.json found. Create one with 'browse init' first.",
+		};
+	}
+
+	const configDir = dirname(configCtx.configPath);
+	const flowsDir = join(configDir, "flows");
+	const outputPath = join(flowsDir, `${resolvedFlowName}.json`);
+	const displayPath =
+		relative(configDir, outputPath) || `${resolvedFlowName}.json`;
+
+	if (existsSync(outputPath) && !force) {
+		return {
+			ok: false,
+			error: `${displayPath} already exists. Use --force to overwrite the generated flow.`,
+		};
+	}
+
+	try {
+		mkdirSync(flowsDir, { recursive: true });
+		writeFileSync(
+			outputPath,
+			`${JSON.stringify(template.flow, null, 2)}\n`,
+			"utf-8",
+		);
+	} catch (error) {
+		return {
+			ok: false,
+			error: `Failed to write flow template: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+
+	return {
+		ok: true,
+		data: `Created ${displayPath} from template ${templateName}.`,
+	};
+}
+
 export async function handleFlow(
 	config: BrowseConfig | null,
 	page: Page,
@@ -42,6 +148,9 @@ export async function handleFlow(
 	customReporters?: CustomReporterRegistry,
 ): Promise<Response> {
 	if (!config) {
+		if (args[0] === "init") {
+			return initFlowFromTemplate(args.slice(1), configCtx);
+		}
 		return {
 			ok: false,
 			error:
@@ -53,12 +162,14 @@ export async function handleFlow(
 	if (args.length === 0) {
 		return {
 			ok: false,
-			error:
-				"Usage: browse flow <name> [--var key=value ...] [--continue-on-error] [--reporter <format>] [--junit-property key=value ...] [--dry-run] [--stream]\nbrowse flow list",
+			error: FLOW_USAGE,
 		};
 	}
 
 	const subcommand = args[0];
+	if (subcommand === "init") {
+		return initFlowFromTemplate(args.slice(1), configCtx);
+	}
 
 	// flow list
 	if (subcommand === "list") {

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -112,6 +112,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 		"--junit-property",
 		"--dry-run",
 		"--stream",
+		"--force",
 	],
 	assert: ["--var", "--json"],
 	healthcheck: [

--- a/src/config.ts
+++ b/src/config.ts
@@ -155,6 +155,7 @@ export type BrowseConfig = {
 /** Passed alongside config so commands can distinguish "not found" from "invalid". */
 export type ConfigContext = {
 	configError?: string | null;
+	configPath?: string | null;
 };
 
 /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -180,6 +180,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 		"--junit-property",
 		"--dry-run",
 		"--stream",
+		"--force",
 		"--webhook",
 	],
 	assert: ["--var", "--json"],
@@ -445,7 +446,10 @@ export async function startServer(
 		flowSources,
 		flowLoadErrors,
 	} = deps;
-	const configCtx = configError ? { configError } : undefined;
+	const configCtx =
+		configError || configPath
+			? { configError, configPath: configPath ?? null }
+			: undefined;
 	const exitFn = options?.onExit ?? (() => process.exit(0));
 	const persistSessionState = options?.persistSessionState === true;
 	const startTime = Date.now();

--- a/src/flow-loader.ts
+++ b/src/flow-loader.ts
@@ -15,6 +15,10 @@ export type FlowDirectory = {
 
 const VALID_FLOW_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
 
+export function isValidFlowName(name: string): boolean {
+	return VALID_FLOW_NAME_RE.test(name);
+}
+
 /**
  * Discover flow directories in precedence order (local first, then global).
  */
@@ -127,7 +131,7 @@ export function loadFlowsFromDirectories(dirs: FlowDirectory[]): {
 		for (const file of files) {
 			const flowName = basename(file, ".json");
 
-			if (!VALID_FLOW_NAME_RE.test(flowName)) {
+			if (!isValidFlowName(flowName)) {
 				errors.push(
 					`Skipping flow file ${file}: invalid flow name '${flowName}'.`,
 				);

--- a/src/flow-templates.ts
+++ b/src/flow-templates.ts
@@ -1,0 +1,51 @@
+import type { FlowConfig } from "./config.ts";
+
+type FlowTemplateDefinition = {
+	summary: string;
+	flow: FlowConfig;
+};
+
+const FLOW_TEMPLATES: Record<string, FlowTemplateDefinition> = {
+	smoke: {
+		summary: "Open a URL and verify expected text",
+		flow: {
+			description: "Smoke-test a page load and verify expected text",
+			variables: ["url", "expected_text"],
+			steps: [
+				{ goto: "{{url}}" },
+				{ assert: { textContains: "{{expected_text}}" } },
+				{ screenshot: true },
+			],
+		},
+	},
+	"login-smoke": {
+		summary: "Sign in to an environment and verify a post-login cue",
+		flow: {
+			description:
+				"Log in to a configured environment and verify a post-login cue",
+			variables: ["environment", "expected_text"],
+			steps: [
+				{ wipe: true },
+				{ login: "{{environment}}" },
+				{ assert: { textContains: "{{expected_text}}" } },
+				{ screenshot: true },
+			],
+		},
+	},
+};
+
+export function getFlowTemplate(
+	name: string,
+): FlowTemplateDefinition | undefined {
+	return FLOW_TEMPLATES[name];
+}
+
+export function getFlowTemplateNames(): string[] {
+	return Object.keys(FLOW_TEMPLATES).sort();
+}
+
+export function formatFlowTemplateList(): string {
+	return getFlowTemplateNames()
+		.map((name) => `  ${name}  ${FLOW_TEMPLATES[name].summary}`)
+		.join("\n");
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -133,11 +133,13 @@ browse tab switch <index>    Switch to tab (1-indexed)
 browse tab close [index]     Close tab (closes active tab if no index)`,
 	},
 	flow: {
-		summary: "Execute a named flow",
+		summary: "Execute or scaffold flows",
 		usage: `browse flow list                          List defined flows
+browse flow init <template> [name] [--force]
 browse flow <name> [--var k=v ...] [--continue-on-error] [--reporter <format>] [--junit-property key=value ...] [--dry-run] [--stream] [--webhook <url>]
 
 Flags:
+  --force              Overwrite an existing generated flow when using init
   --var key=value       Pass variables to flow (repeatable)
   --continue-on-error   Continue running steps even if one fails
   --reporter <format>   Output format: ${FLOW_REPORTER_HELP}, or a plugin-provided reporter name
@@ -150,7 +152,11 @@ Flows can be defined inline in browse.config.json or as individual JSON files
 in a flows/ directory next to the config file. Global flows in ~/.browse/flows/
 are also loaded. Inline flows take precedence over file-based flows.
 Flows support conditional logic (if/else) and loops (while) with condition
-expressions.`,
+expressions.
+
+Built-in templates:
+  smoke        Open a URL and verify expected text
+  login-smoke  Sign in to an environment and verify a post-login cue`,
 	},
 	assert: {
 		summary: "Assert a condition (PASS/FAIL)",

--- a/test/flow-daemon-template-init.test.ts
+++ b/test/flow-daemon-template-init.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { connect } from "node:net";
+import { join } from "node:path";
+import type { BrowseConfig } from "../src/config.ts";
+import { type ServerDeps, startServer } from "../src/daemon.ts";
+import type { LifecycleConfig } from "../src/lifecycle.ts";
+import type { Response } from "../src/protocol.ts";
+
+const TEST_DIR = join(import.meta.dir, ".tmp-flow-daemon-template-init");
+let testIndex = 0;
+
+function testPaths(): LifecycleConfig & { dir: string } {
+	testIndex++;
+	const dir = join(TEST_DIR, `run-${testIndex}`);
+	mkdirSync(dir, { recursive: true });
+	return {
+		dir,
+		socketPath: join(dir, "test.sock"),
+		pidPath: join(dir, "test.pid"),
+		idleTimeoutMs: 60_000,
+	};
+}
+
+function mockPage(overrides: Record<string, unknown> = {}) {
+	return {
+		goto: mock(() => Promise.resolve()),
+		title: mock(() => Promise.resolve("Mock Title")),
+		innerText: mock(() => Promise.resolve("Mock body text")),
+		on: mock(() => {}),
+		mainFrame: mock(() => ({})),
+		url: mock(() => "https://example.com"),
+		...overrides,
+	} as never;
+}
+
+function mockContext(overrides: Record<string, unknown> = {}) {
+	return {
+		storageState: mock(() => Promise.resolve({ cookies: [], origins: [] })),
+		addCookies: mock(() => Promise.resolve()),
+		newPage: mock(() => Promise.resolve(mockPage())),
+		...overrides,
+	} as never;
+}
+
+function mockDeps(
+	page: ReturnType<typeof mockPage>,
+	overrides: Partial<ServerDeps> = {},
+): ServerDeps {
+	return {
+		page,
+		context: mockContext(),
+		config: null,
+		...overrides,
+	};
+}
+
+function sendCommand(
+	socketPath: string,
+	cmd: string,
+	args: string[] = [],
+): Promise<Response> {
+	return new Promise((resolve, reject) => {
+		const client = connect(socketPath, () => {
+			client.write(`${JSON.stringify({ cmd, args })}\n`);
+		});
+
+		let buffer = "";
+		client.on("data", (chunk) => {
+			buffer += chunk.toString();
+			const newlineIndex = buffer.indexOf("\n");
+			if (newlineIndex === -1) return;
+			const line = buffer.slice(0, newlineIndex).trim();
+			client.end();
+			resolve(JSON.parse(line));
+		});
+		client.on("error", reject);
+	});
+}
+
+const BASE_CONFIG: BrowseConfig = {
+	environments: {
+		staging: {
+			loginUrl: "https://example.com/login",
+			userEnvVar: "STAGING_USER",
+			passEnvVar: "STAGING_PASS",
+			successCondition: { urlContains: "/dashboard" },
+		},
+	},
+};
+
+beforeEach(() => {
+	mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+	rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("daemon flow init", () => {
+	test("accepts --force for flow init and writes the template file", async () => {
+		const config = testPaths();
+		const projectDir = join(config.dir, "project");
+		mkdirSync(projectDir, { recursive: true });
+		const configPath = join(projectDir, "browse.config.json");
+		writeFileSync(
+			configPath,
+			`${JSON.stringify(BASE_CONFIG, null, 2)}\n`,
+			"utf-8",
+		);
+
+		const page = mockPage();
+		const { shutdown } = await startServer(
+			mockDeps(page, {
+				config: BASE_CONFIG,
+				configPath,
+			}),
+			config,
+			async () => {},
+		);
+
+		try {
+			const response = await sendCommand(config.socketPath, "flow", [
+				"init",
+				"smoke",
+				"release-smoke",
+				"--force",
+			]);
+			expect(response.ok).toBe(true);
+			expect(existsSync(join(projectDir, "flows", "release-smoke.json"))).toBe(
+				true,
+			);
+		} finally {
+			await shutdown();
+		}
+	});
+});

--- a/test/flow-template-init.test.ts
+++ b/test/flow-template-init.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleFlow } from "../src/commands/flow.ts";
+import type { BrowseConfig, ConfigContext } from "../src/config.ts";
+import { loadFlowFile } from "../src/flow-loader.ts";
+
+const BASE_CONFIG: BrowseConfig = {
+	environments: {
+		staging: {
+			loginUrl: "https://example.com/login",
+			userEnvVar: "STAGING_USER",
+			passEnvVar: "STAGING_PASS",
+			successCondition: { urlContains: "/dashboard" },
+		},
+	},
+};
+
+const testRoots = new Set<string>();
+
+function createProject(): {
+	root: string;
+	configPath: string;
+	configCtx: ConfigContext;
+} {
+	const root = join(
+		tmpdir(),
+		`browse-flow-template-init-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	mkdirSync(root, { recursive: true });
+	testRoots.add(root);
+
+	const configPath = join(root, "browse.config.json");
+	writeFileSync(
+		configPath,
+		`${JSON.stringify(BASE_CONFIG, null, 2)}\n`,
+		"utf-8",
+	);
+
+	return {
+		root,
+		configPath,
+		configCtx: { configPath },
+	};
+}
+
+afterEach(() => {
+	for (const root of testRoots) {
+		rmSync(root, { recursive: true, force: true });
+	}
+	testRoots.clear();
+});
+
+describe("handleFlow - flow init", () => {
+	test("shows usage and available templates when the template is missing", async () => {
+		const { configCtx } = createProject();
+
+		const result = await handleFlow(
+			BASE_CONFIG,
+			null as any,
+			["init"],
+			undefined,
+			configCtx,
+		);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain(
+				"Usage: browse flow init <template> [name] [--force]",
+			);
+			expect(result.error).toContain("smoke");
+			expect(result.error).toContain("login-smoke");
+		}
+	});
+
+	test("scaffolds a smoke template into flows/ beside the config", async () => {
+		const { root, configCtx } = createProject();
+
+		const result = await handleFlow(
+			BASE_CONFIG,
+			null as any,
+			["init", "smoke", "checkout-smoke"],
+			undefined,
+			configCtx,
+		);
+
+		const flowPath = join(root, "flows", "checkout-smoke.json");
+		expect(result.ok).toBe(true);
+		expect(existsSync(flowPath)).toBe(true);
+		const { flow, error } = loadFlowFile(flowPath);
+		expect(error).toBeNull();
+		expect(flow?.variables).toEqual(["url", "expected_text"]);
+		expect(readFileSync(flowPath, "utf-8")).toContain("{{url}}");
+		if (result.ok) {
+			expect(result.data).toContain("Created flows/checkout-smoke.json");
+		}
+	});
+
+	test("refuses to overwrite an existing flow without --force", async () => {
+		const { root, configCtx } = createProject();
+		const flowsDir = join(root, "flows");
+		mkdirSync(flowsDir, { recursive: true });
+		writeFileSync(
+			join(flowsDir, "smoke.json"),
+			JSON.stringify({ steps: [{ goto: "https://old.example.com" }] }, null, 2),
+			"utf-8",
+		);
+
+		const result = await handleFlow(
+			BASE_CONFIG,
+			null as any,
+			["init", "smoke"],
+			undefined,
+			configCtx,
+		);
+
+		expect(result).toEqual({
+			ok: false,
+			error:
+				"flows/smoke.json already exists. Use --force to overwrite the generated flow.",
+		});
+	});
+
+	test("overwrites an existing flow when --force is provided", async () => {
+		const { root, configCtx } = createProject();
+		const flowsDir = join(root, "flows");
+		mkdirSync(flowsDir, { recursive: true });
+		const flowPath = join(flowsDir, "smoke.json");
+		writeFileSync(
+			flowPath,
+			JSON.stringify({ steps: [{ goto: "https://old.example.com" }] }, null, 2),
+			"utf-8",
+		);
+
+		const result = await handleFlow(
+			BASE_CONFIG,
+			null as any,
+			["init", "smoke", "smoke", "--force"],
+			undefined,
+			configCtx,
+		);
+
+		expect(result.ok).toBe(true);
+		expect(readFileSync(flowPath, "utf-8")).toContain('"expected_text"');
+	});
+
+	test("returns a helpful error for an unknown template", async () => {
+		const { configCtx } = createProject();
+
+		const result = await handleFlow(
+			BASE_CONFIG,
+			null as any,
+			["init", "unknown-template"],
+			undefined,
+			configCtx,
+		);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain(
+				"Unknown flow template 'unknown-template'",
+			);
+			expect(result.error).toContain("smoke");
+			expect(result.error).toContain("login-smoke");
+		}
+	});
+
+	test("rejects reserved flow names that would shadow subcommands", async () => {
+		const { configCtx } = createProject();
+
+		const result = await handleFlow(
+			BASE_CONFIG,
+			null as any,
+			["init", "smoke", "list"],
+			undefined,
+			configCtx,
+		);
+
+		expect(result).toEqual({
+			ok: false,
+			error:
+				"Invalid flow name 'list'. 'init' and 'list' are reserved for flow subcommands.",
+		});
+	});
+});

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -89,6 +89,14 @@ describe("formatCommandHelp", () => {
 		expect(help).toContain("html");
 	});
 
+	test("documents flow template scaffolding", () => {
+		const help = formatCommandHelp("flow");
+		expect(help).not.toBeNull();
+		expect(help).toContain("browse flow init <template> [name] [--force]");
+		expect(help).toContain("smoke");
+		expect(help).toContain("login-smoke");
+	});
+
 	test("documents additional reporters for test-matrix", () => {
 		const help = formatCommandHelp("test-matrix");
 		expect(help).not.toBeNull();


### PR DESCRIPTION
## Summary
- add `browse flow init <template> [name] [--force]` to scaffold built-in `smoke` and `login-smoke` flow starters next to the active config
- reject reserved flow names, pass config paths through the daemon, and cover the new command path with command and daemon tests
- update the README, command docs, flow docs, browse skill, and roadmap entry for the shipped roadmap slice

## Testing
- `bun run check:fix`
- `bun test`
- `./setup.sh`

Closes #176