### PR TITLE
fix: pin Bun to 1.3.11 in CI

### DIFF
--- a/.github/actions/browse/action.yml
+++ b/.github/actions/browse/action.yml
@@ -13,7 +13,7 @@ inputs:
   bun-version:
     description: "Bun version to install"
     required: false
-    default: "latest"
+    default: "1.3.11"
   browser:
     description: "Patchright browser channel to install"
     required: false

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Bun
-        run: |
-          curl -fsSL https://bun.sh/install | bash
-          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Bun
-        run: |
-          curl -fsSL https://bun.sh/install | bash
-          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Bun
-        run: |
-          curl -fsSL https://bun.sh/install | bash
-          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Inputs:
 |-------|---------|-------------|
 | `command` | `healthcheck` | Browse command to run |
 | `config` | `browse.config.json` | Path to the config file in your repository |
-| `bun-version` | `latest` | Bun version installed by the action |
+| `bun-version` | `1.3.11` | Bun version installed by the action |
 | `browser` | `chrome` | Patchright browser channel installed by the action |
 
 The action executes `browse` from the action checkout, but runs it against your repository workspace so relative config paths, flows, and output files still behave normally.

--- a/src/commands/ci-init.ts
+++ b/src/commands/ci-init.ts
@@ -2,6 +2,8 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Response } from "../protocol.ts";
 
+const BUN_VERSION = "1.3.11";
+
 const GITHUB_ACTIONS_TEMPLATE = `name: Browse QA
 
 on:
@@ -18,6 +20,8 @@ jobs:
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${BUN_VERSION}
 
       - name: Install dependencies
         run: bun install
@@ -37,7 +41,7 @@ jobs:
 const GITLAB_CI_TEMPLATE = `browse-qa:
   image: node:20
   before_script:
-    - curl -fsSL https://bun.sh/install | bash
+    - curl -fsSL https://bun.sh/install | bash -s -- bun-v${BUN_VERSION}
     - export PATH="$HOME/.bun/bin:$PATH"
     - bun install
     - ./setup.sh
@@ -58,7 +62,7 @@ jobs:
       - checkout
       - run:
           name: Install Bun
-          command: curl -fsSL https://bun.sh/install | bash
+          command: curl -fsSL https://bun.sh/install | bash -s -- bun-v${BUN_VERSION}
       - run:
           name: Build browse
           command: |


### PR DESCRIPTION
## Summary
- pin the release, CI, and benchmark GitHub workflows to Bun 1.3.11 instead of installing the latest available version
- update the reusable GitHub Action default and generated CI templates so new configs also stay on the known-good Bun version
- document the pinned default in the README while Bun 1.3.12 produces macOS arm64 binaries that fail ad-hoc signing in release CI

## Testing
- git diff --check
- bunx biome check src/commands/ci-init.ts README.md