### PR TITLE
fix: resolve correctness and security findings from full-repo review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,19 @@ jobs:
         if: runner.os == 'Linux' && matrix.label != 'linux-arm64'
         run: bun x patchright install chrome --with-deps
 
+      # Prefer the Chrome preinstalled on GitHub macOS images. patchright's
+      # installer deletes /Applications/Google Chrome.app before downloading,
+      # and dl.google.com intermittently serves runners a stub response —
+      # which would leave the runner with no Chrome at all.
       - name: Install browser binaries (macOS)
         if: runner.os != 'Linux'
-        run: bun x patchright install chrome
+        run: |
+          if [ -d "/Applications/Google Chrome.app" ]; then
+            echo "Using preinstalled Google Chrome"
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --version
+          else
+            bun x patchright install chrome
+          fi
 
       - name: Run tests
         run: bun test

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ RUN bun run build
 
 FROM mcr.microsoft.com/playwright:v1.54.1-noble AS runtime
 WORKDIR /work
+# The compiled binary embeds patchright (see package.json), whose expected
+# browser revisions differ from the base image's; browse also defaults to
+# the "chrome" channel, which Playwright base images don't ship. Install a
+# matching Chrome so commands beyond --help actually work.
+RUN npx -y patchright@1.58.2 install chrome --with-deps
 COPY --from=build /app/dist/browse /usr/local/bin/browse
 ENTRYPOINT ["browse"]
 CMD ["--help"]

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,7 +8,9 @@ Browse has a plugin system that lets you add custom commands and hook into the c
 
 ```typescript
 // plugins/hello.ts
-import type { BrowsePlugin } from "browse/plugin";
+// Import the plugin types from the browse repo's src/plugin.ts
+// (adjust the relative path to where browse is checked out)
+import type { BrowsePlugin } from "../path/to/browse/src/plugin.ts";
 
 const plugin: BrowsePlugin = {
   name: "hello",
@@ -266,8 +268,8 @@ npm install browse-plugin-foo
 }
 ```
 
-For type safety during development, install `browse` as a dev dependency and import the types:
+For type safety during development, import the types from the browse repo's `src/plugin.ts` (browse is not published to npm, so use a relative path to a checkout — see `examples/plugins/` for working examples):
 
 ```typescript
-import type { BrowsePlugin, CommandContext } from "browse/plugin";
+import type { BrowsePlugin, CommandContext } from "../path/to/browse/src/plugin.ts";
 ```

--- a/install.sh
+++ b/install.sh
@@ -75,10 +75,12 @@ fi
 
 echo "  binary: ${BIN_DIR}/browse"
 
-# Install Chrome for Testing (matches setup.sh and CI)
+# Install Chrome for Testing (matches setup.sh and CI). The release binary
+# embeds patchright, so browsers must be installed via patchright — upstream
+# playwright fetches different browser revisions the binary won't find.
 echo ""
 echo "Installing Chrome..."
-bunx playwright install chrome
+bunx patchright install chrome
 echo "  Chrome installed"
 
 # Optional: install additional browsers via BROWSE_BROWSERS env var
@@ -86,7 +88,7 @@ echo "  Chrome installed"
 if [ -n "$BROWSE_BROWSERS" ]; then
   for EXTRA_BROWSER in $BROWSE_BROWSERS; do
     echo "  Installing $EXTRA_BROWSER..."
-    bunx playwright install "$EXTRA_BROWSER"
+    bunx patchright install "$EXTRA_BROWSER"
     echo "  $EXTRA_BROWSER installed"
   done
 fi

--- a/src/commands/a11y.ts
+++ b/src/commands/a11y.ts
@@ -417,15 +417,14 @@ async function auditTabOrder(page: Page, json: boolean): Promise<Response> {
 async function auditHeadings(page: Page, json: boolean): Promise<Response> {
 	const headings = await page.evaluate(() => {
 		const result: { level: number; text: string }[] = [];
-		for (const tag of ["h1", "h2", "h3", "h4", "h5", "h6"]) {
-			for (const el of document.querySelectorAll(tag)) {
-				result.push({
-					level: Number.parseInt(tag[1], 10),
-					text: (el as HTMLElement).innerText?.trim().slice(0, 80) ?? "",
-				});
-			}
+		// querySelectorAll returns elements in document order, which the
+		// heading-skip check below depends on
+		for (const el of document.querySelectorAll("h1,h2,h3,h4,h5,h6")) {
+			result.push({
+				level: Number.parseInt(el.tagName[1], 10),
+				text: (el as HTMLElement).innerText?.trim().slice(0, 80) ?? "",
+			});
 		}
-		// Sort by document order
 		return result;
 	});
 

--- a/src/commands/back.ts
+++ b/src/commands/back.ts
@@ -27,10 +27,11 @@ export async function handleBack(page: Page): Promise<Response> {
 				}
 			}
 		};
-		await Promise.race([
-			page.goBack({ waitUntil: "domcontentloaded" }),
-			pollForUrlChange(),
-		]);
+		const navigation = page.goBack({ waitUntil: "domcontentloaded" });
+		// If the poller wins the race, the navigation promise may still reject
+		// later (e.g. timeout) — swallow it to avoid an unhandled rejection.
+		navigation.catch(() => {});
+		await Promise.race([navigation, pollForUrlChange()]);
 		const title = await page.title();
 		return { ok: true, data: title };
 	} catch (err) {

--- a/src/commands/compliance.ts
+++ b/src/commands/compliance.ts
@@ -47,15 +47,24 @@ export async function handleCompliance(
 	// Navigate to URL if provided
 	const targetUrl = args.find((a) => a.startsWith("http"));
 
-	// Use a fresh browser context for compliance auditing to avoid
+	// When a URL is given, audit it in a fresh browser context to avoid
 	// polluted state (existing cookies, storage) from the current session.
+	// Without a URL, audit the current page in its own context — a fresh
+	// context would have none of the page's cookies.
 	const browser = deps.context.browser();
-	const freshContext = browser ? await browser.newContext() : null;
+	const freshContext = browser && targetUrl ? await browser.newContext() : null;
 	const auditContext = freshContext ?? deps.context;
 	let auditPage = page;
 
-	if (freshContext && targetUrl) {
+	// Requests captured for the fresh-context page; the session network
+	// buffer only sees the main session's tabs.
+	const capturedRequests: string[] = [];
+
+	if (freshContext) {
 		auditPage = await freshContext.newPage();
+		auditPage.on("request", (req) => {
+			capturedRequests.push(req.url());
+		});
 	}
 
 	try {
@@ -213,18 +222,20 @@ export async function handleCompliance(
 		}
 
 		// 3. Third-party tracker detection
-		const networkEntries = deps.networkBuffer.peek();
+		const requestUrls = freshContext
+			? capturedRequests
+			: deps.networkBuffer.peek().map((entry) => entry.url);
 		const trackerRequests: {
 			url: string;
 			tracker: string;
 			category: string;
 		}[] = [];
 
-		for (const entry of networkEntries) {
-			const classified = classifyDomain(entry.url);
+		for (const url of requestUrls) {
+			const classified = classifyDomain(url);
 			if (classified) {
 				trackerRequests.push({
-					url: entry.url,
+					url,
 					tracker: classified.tracker,
 					category: classified.category,
 				});

--- a/src/commands/cookies.ts
+++ b/src/commands/cookies.ts
@@ -26,7 +26,7 @@ export async function handleCookies(
 					(c) =>
 						c.domain === domain ||
 						c.domain === `.${domain}` ||
-						(c.domain.startsWith(".") && domain.endsWith(c.domain.slice(1))),
+						(c.domain.startsWith(".") && domain.endsWith(c.domain)),
 				)
 			: cookies;
 

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -42,7 +42,7 @@ export async function handleDiff(
 	config: BrowseConfig | null,
 	_page: Page,
 	args: string[],
-	_deps: DiffDeps,
+	deps: DiffDeps,
 	context: BrowserContext,
 ): Promise<Response> {
 	// Parse args

--- a/src/commands/do.ts
+++ b/src/commands/do.ts
@@ -181,29 +181,47 @@ export async function handleDo(page: Page, args: string[]): Promise<Response> {
 					messages: [{ role: "user", content: userPrompt }],
 				}),
 			});
+			if (!resp.ok) {
+				const body = await resp.text();
+				return {
+					ok: false,
+					error: `Anthropic API error (${resp.status}): ${body.slice(0, 200)}`,
+				};
+			}
 			const data = (await resp.json()) as {
 				content?: { text?: string }[];
 			};
 			commandsJson = data.content?.[0]?.text ?? "[]";
 		} else {
-			const resp = await fetch(
-				`${baseUrl ?? process.env.OPENAI_BASE_URL ?? "https://api.openai.com"}/v1/chat/completions`,
-				{
-					method: "POST",
-					headers: {
-						"Content-Type": "application/json",
-						Authorization: `Bearer ${apiKey}`,
-					},
-					body: JSON.stringify({
-						model: model ?? "gpt-4o",
-						messages: [
-							{ role: "system", content: systemPrompt },
-							{ role: "user", content: userPrompt },
-						],
-						max_tokens: 1024,
-					}),
+			// Base URL is expected to already include the API version segment
+			// (e.g. https://openrouter.ai/api/v1), matching assert-ai
+			const apiBase = (
+				baseUrl ??
+				process.env.OPENAI_BASE_URL ??
+				"https://api.openai.com/v1"
+			).replace(/\/$/, "");
+			const resp = await fetch(`${apiBase}/chat/completions`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${apiKey}`,
 				},
-			);
+				body: JSON.stringify({
+					model: model ?? "gpt-4o",
+					messages: [
+						{ role: "system", content: systemPrompt },
+						{ role: "user", content: userPrompt },
+					],
+					max_tokens: 1024,
+				}),
+			});
+			if (!resp.ok) {
+				const body = await resp.text();
+				return {
+					ok: false,
+					error: `OpenAI API error (${resp.status}): ${body.slice(0, 200)}`,
+				};
+			}
 			const data = (await resp.json()) as {
 				choices?: { message?: { content?: string } }[];
 			};

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -90,6 +90,7 @@ async function extractTable(
 
 	// Resolve @ref if needed
 	let selector = selectorArg;
+	let nthIndex = 0;
 	if (selectorArg.startsWith("@")) {
 		const resolved = resolveRef(selectorArg);
 		if ("error" in resolved) {
@@ -101,69 +102,74 @@ async function extractTable(
 				error: `Ref ${selectorArg} points to a "${resolved.role}" element, not a table.`,
 			};
 		}
-		// Build a selector that targets this specific table via nth-match
-		selector =
-			resolved.totalMatches > 1
-				? `table:nth-of-type(${resolved.nthMatch})`
-				: "table";
+		// Target this specific table by its 0-based document-order index
+		selector = "table";
+		nthIndex = resolved.nthMatch;
 	}
 
-	const tableData = await page.evaluate((sel) => {
-		const table = document.querySelector(sel);
-		if (!table) return null;
+	const tableData = await page.evaluate(
+		({ sel, index }) => {
+			const table = document.querySelectorAll(sel)[index];
+			if (!table) return null;
 
-		const headers: string[] = [];
-		const rows: string[][] = [];
+			const headers: string[] = [];
+			const rows: string[][] = [];
 
-		const ths = table.querySelectorAll("thead th, thead td, tr:first-child th");
-		if (ths.length > 0) {
-			for (const th of ths) {
-				headers.push(
-					(th as HTMLElement).innerText?.trim() ?? th.textContent?.trim() ?? "",
-				);
+			const ths = table.querySelectorAll(
+				"thead th, thead td, tr:first-child th",
+			);
+			if (ths.length > 0) {
+				for (const th of ths) {
+					headers.push(
+						(th as HTMLElement).innerText?.trim() ??
+							th.textContent?.trim() ??
+							"",
+					);
+				}
 			}
-		}
 
-		// Select body rows, excluding any inside thead
-		const hasTbody = table.querySelector("tbody");
-		const allRows = hasTbody
-			? table.querySelectorAll("tbody tr")
-			: table.querySelectorAll("tr");
-		let bodyRows = Array.from(allRows).filter((tr) => !tr.closest("thead"));
-		// Skip first row if it's header-like (all th cells) and headers were already captured
-		if (
-			headers.length > 0 &&
-			bodyRows.length > 0 &&
-			bodyRows[0].querySelectorAll("th").length > 0 &&
-			bodyRows[0].querySelectorAll("td").length === 0
-		) {
-			bodyRows = bodyRows.slice(1);
-		}
-
-		for (let i = 0; i < bodyRows.length; i++) {
-			const cells = bodyRows[i].querySelectorAll("td, th");
-			const row: string[] = [];
-			for (const cell of cells) {
-				row.push(
-					(cell as HTMLElement).innerText?.trim() ??
-						cell.textContent?.trim() ??
-						"",
-				);
+			// Select body rows, excluding any inside thead
+			const hasTbody = table.querySelector("tbody");
+			const allRows = hasTbody
+				? table.querySelectorAll("tbody tr")
+				: table.querySelectorAll("tr");
+			let bodyRows = Array.from(allRows).filter((tr) => !tr.closest("thead"));
+			// Skip first row if it's header-like (all th cells) and headers were already captured
+			if (
+				headers.length > 0 &&
+				bodyRows.length > 0 &&
+				bodyRows[0].querySelectorAll("th").length > 0 &&
+				bodyRows[0].querySelectorAll("td").length === 0
+			) {
+				bodyRows = bodyRows.slice(1);
 			}
-			if (row.length > 0) {
-				rows.push(row);
-			}
-		}
 
-		// If no headers found, use column indices
-		if (headers.length === 0 && rows.length > 0) {
-			for (let i = 0; i < rows[0].length; i++) {
-				headers.push(`col${i + 1}`);
+			for (let i = 0; i < bodyRows.length; i++) {
+				const cells = bodyRows[i].querySelectorAll("td, th");
+				const row: string[] = [];
+				for (const cell of cells) {
+					row.push(
+						(cell as HTMLElement).innerText?.trim() ??
+							cell.textContent?.trim() ??
+							"",
+					);
+				}
+				if (row.length > 0) {
+					rows.push(row);
+				}
 			}
-		}
 
-		return { headers, rows };
-	}, selector);
+			// If no headers found, use column indices
+			if (headers.length === 0 && rows.length > 0) {
+				for (let i = 0; i < rows[0].length; i++) {
+					headers.push(`col${i + 1}`);
+				}
+			}
+
+			return { headers, rows };
+		},
+		{ sel: selector, index: nthIndex },
+	);
 
 	if (!tableData) {
 		return { ok: false, error: `No table found matching "${selector}".` };

--- a/src/commands/forward.ts
+++ b/src/commands/forward.ts
@@ -30,10 +30,11 @@ export async function handleForward(page: Page): Promise<Response> {
 				}
 			}
 		};
-		await Promise.race([
-			page.goForward({ waitUntil: "domcontentloaded" }),
-			pollForUrlChange(),
-		]);
+		const navigation = page.goForward({ waitUntil: "domcontentloaded" });
+		// If the poller wins the race, the navigation promise may still reject
+		// later (e.g. timeout) — swallow it to avoid an unhandled rejection.
+		navigation.catch(() => {});
+		await Promise.race([navigation, pollForUrlChange()]);
 		const title = await page.title();
 		return { ok: true, data: title };
 	} catch (err) {

--- a/src/commands/gesture.ts
+++ b/src/commands/gesture.ts
@@ -1,6 +1,14 @@
 import type { Page } from "playwright";
 import type { Response } from "../protocol.ts";
-import { resolveRef } from "../refs.ts";
+import { type RefEntry, resolveRef } from "../refs.ts";
+
+function refLocator(page: Page, resolved: RefEntry) {
+	const locator = page.getByRole(
+		resolved.role as Parameters<Page["getByRole"]>[0],
+		{ name: resolved.name, exact: true },
+	);
+	return resolved.totalMatches > 1 ? locator.nth(resolved.nthMatch) : locator;
+}
 
 export async function handleGesture(
 	page: Page,
@@ -78,10 +86,7 @@ async function handleSwipe(page: Page, args: string[]): Promise<Response> {
 		if ("error" in resolved) {
 			return { ok: false, error: resolved.error };
 		}
-		const locator = page.getByRole(
-			resolved.role as Parameters<typeof page.getByRole>[0],
-			{ name: resolved.name, exact: true },
-		);
+		const locator = refLocator(page, resolved);
 		const box = await locator.boundingBox();
 		if (!box) {
 			return { ok: false, error: `Could not find bounding box for ${refArg}` };
@@ -182,10 +187,7 @@ async function handleLongPress(page: Page, args: string[]): Promise<Response> {
 	}
 
 	try {
-		const locator = page.getByRole(
-			resolved.role as Parameters<typeof page.getByRole>[0],
-			{ name: resolved.name, exact: true },
-		);
+		const locator = refLocator(page, resolved);
 		const box = await locator.boundingBox();
 		if (!box) {
 			return { ok: false, error: `Could not find bounding box for ${ref}` };
@@ -244,10 +246,7 @@ async function handleDoubleTap(page: Page, args: string[]): Promise<Response> {
 	}
 
 	try {
-		const locator = page.getByRole(
-			resolved.role as Parameters<typeof page.getByRole>[0],
-			{ name: resolved.name, exact: true },
-		);
+		const locator = refLocator(page, resolved);
 
 		const box = await locator.boundingBox();
 		if (!box) {
@@ -331,14 +330,8 @@ async function handleDrag(page: Page, args: string[]): Promise<Response> {
 	}
 
 	try {
-		const srcLocator = page.getByRole(
-			source.role as Parameters<typeof page.getByRole>[0],
-			{ name: source.name, exact: true },
-		);
-		const tgtLocator = page.getByRole(
-			target.role as Parameters<typeof page.getByRole>[0],
-			{ name: target.name, exact: true },
-		);
+		const srcLocator = refLocator(page, source);
+		const tgtLocator = refLocator(page, target);
 
 		await srcLocator.dragTo(tgtLocator, { timeout: 10_000 });
 

--- a/src/commands/intercept.ts
+++ b/src/commands/intercept.ts
@@ -75,11 +75,15 @@ export async function handleIntercept(
 			state.rules.set(pattern, rule);
 
 			await page.route(pattern, (route) => {
-				route.fulfill({
-					status: rule.status,
-					body: rule.body,
-					contentType: rule.contentType,
-				});
+				// Fulfillment can fail if the request was cancelled (e.g. the
+				// page navigated away) — swallow to avoid unhandled rejections.
+				route
+					.fulfill({
+						status: rule.status,
+						body: rule.body,
+						contentType: rule.contentType,
+					})
+					.catch(() => {});
 			});
 
 			return {

--- a/src/commands/page-eval.ts
+++ b/src/commands/page-eval.ts
@@ -21,20 +21,27 @@ export async function handlePageEval(
 		};
 	}
 
+	// Only fall back to the unwrapped form when *construction* fails
+	// (statements that can't be parenthesized). Falling back on runtime
+	// errors would re-execute side-effectful code a second time.
+	let fn: (page: Page) => Promise<unknown>;
 	try {
-		const fn = new AsyncFunction("page", `return (${expression});`);
-		const result = await fn(page);
-		return { ok: true, data: formatResult(result) };
+		fn = new AsyncFunction("page", `return (${expression});`);
 	} catch {
-		// Retry without wrapping in parens — handles statements like `throw ...`
 		try {
-			const fn = new AsyncFunction("page", expression);
-			const result = await fn(page);
-			return { ok: true, data: formatResult(result) };
+			fn = new AsyncFunction("page", expression);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			return { ok: false, error: message };
 		}
+	}
+
+	try {
+		const result = await fn(page);
+		return { ok: true, data: formatResult(result) };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { ok: false, error: message };
 	}
 }
 

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -15,6 +15,14 @@ import {
 	stopSession,
 } from "../recorder.ts";
 
+// The active navigation listener, so recordStop can detach it. Without
+// removal, each start/stop cycle would stack another listener and record
+// duplicate goto steps.
+let navListener: {
+	page: Page;
+	handler: (frame: import("playwright").Frame) => void;
+} | null = null;
+
 function parseFlag(args: string[], flag: string): string | null {
 	const idx = args.indexOf(flag);
 	if (idx === -1 || idx + 1 >= args.length) return null;
@@ -51,8 +59,8 @@ async function recordStart(page: Page, args: string[]): Promise<Response> {
 		// Function may already be exposed from a previous session
 	}
 
-	// Listen for navigations
-	page.on("framenavigated", (frame) => {
+	// Listen for navigations (detached again in recordStop)
+	const handler = (frame: import("playwright").Frame) => {
 		if (frame === page.mainFrame()) {
 			pushEvent({
 				type: "navigation",
@@ -60,7 +68,9 @@ async function recordStart(page: Page, args: string[]): Promise<Response> {
 				timestamp: Date.now(),
 			});
 		}
-	});
+	};
+	navListener = { page, handler };
+	page.on("framenavigated", handler);
 
 	// Inject the observer script
 	const script = getInjectedScript();
@@ -78,6 +88,15 @@ async function recordStart(page: Page, args: string[]): Promise<Response> {
 async function recordStop(): Promise<Response> {
 	if (!isRecording()) {
 		return { ok: false, error: "No recording in progress." };
+	}
+
+	if (navListener) {
+		try {
+			navListener.page.off("framenavigated", navListener.handler);
+		} catch {
+			// Page may already be closed
+		}
+		navListener = null;
 	}
 
 	const { config, outputPath } = stopSession();

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -39,6 +39,8 @@ export type SessionCallbacks = {
 	/** The shared (default) browser context */
 	defaultContext: BrowserContext;
 	attachListeners: (page: Page, tabState: TabState) => void;
+	/** Notify the daemon that a session was closed, so per-session state can be released */
+	onClose?: (name: string) => void;
 };
 
 const VALID_SUBCOMMANDS = ["list", "create", "close"] as const;
@@ -68,7 +70,7 @@ export async function handleSession(
 		case "create":
 			return handleCreate(registry, args, callbacks);
 		case "close":
-			return handleClose(registry, args);
+			return handleClose(registry, args, callbacks);
 		default:
 			throw new Error(`Unexpected subcommand: ${subcommand}`);
 	}
@@ -162,6 +164,7 @@ async function handleCreate(
 async function handleClose(
 	registry: SessionRegistry,
 	args: string[],
+	callbacks: SessionCallbacks,
 ): Promise<Response> {
 	const name = args[1];
 	if (!name) {
@@ -205,6 +208,7 @@ async function handleClose(
 	}
 
 	registry.sessions.delete(name);
+	callbacks.onClose?.(name);
 
 	return {
 		ok: true,

--- a/src/commands/subscribe.ts
+++ b/src/commands/subscribe.ts
@@ -39,7 +39,7 @@ export async function handleSubscribe(
 
 	// Parse --status filter
 	const statusIdx = args.indexOf("--status");
-	const _statusFilter =
+	const statusFilter =
 		statusIdx !== -1 && statusIdx + 1 < args.length
 			? args[statusIdx + 1]
 			: undefined;
@@ -108,6 +108,46 @@ export async function handleSubscribe(
 		};
 		page.on("dialog", handler);
 		listeners.push(() => page.off("dialog", handler));
+	}
+
+	if (eventTypes.includes("network")) {
+		const handler = (response: {
+			url: () => string;
+			status: () => number;
+			request: () => { method: () => string };
+		}) => {
+			const status = response.status();
+			if (statusFilter && String(status) !== statusFilter) return;
+			addEvent({
+				ts: new Date().toISOString(),
+				event: "network",
+				data: {
+					url: response.url(),
+					status,
+					method: response.request().method(),
+				},
+			});
+		};
+		page.on("response", handler);
+		listeners.push(() => page.off("response", handler));
+	}
+
+	if (eventTypes.includes("download")) {
+		const handler = (download: {
+			url: () => string;
+			suggestedFilename: () => string;
+		}) => {
+			addEvent({
+				ts: new Date().toISOString(),
+				event: "download",
+				data: {
+					url: download.url(),
+					filename: download.suggestedFilename(),
+				},
+			});
+		};
+		page.on("download", handler);
+		listeners.push(() => page.off("download", handler));
 	}
 
 	if (eventTypes.includes("error")) {

--- a/src/commands/throttle.ts
+++ b/src/commands/throttle.ts
@@ -109,8 +109,12 @@ export async function handleThrottle(
 		upload = preset.upload;
 		latency = preset.latency;
 		presetName = sub;
-	} else if (sub === "--download" || args.includes("--download")) {
-		// Custom values
+	} else if (
+		args.some(
+			(a) => a === "--download" || a === "--upload" || a === "--latency",
+		)
+	) {
+		// Custom values — any of the three flags can be used independently
 		download = parseNumericFlag(args, "--download", 500) * 1024;
 		upload = parseNumericFlag(args, "--upload", 100) * 1024;
 		latency = parseNumericFlag(args, "--latency", 0);

--- a/src/commands/vrt.ts
+++ b/src/commands/vrt.ts
@@ -268,9 +268,12 @@ async function vrtCheck(
 		const currentPath = join(currentDir, baselineFile);
 		await page.screenshot({ path: currentPath, fullPage: true });
 
-		// Compare
+		// Compare. The vrt threshold is a pass/fail *percentage*; the third
+		// argument of compareScreenshots is a per-pixel colour tolerance
+		// (0-255), so keep the library default there rather than conflating
+		// the two meanings.
 		const baselinePath = join(baselinesDir, baselineFile);
-		const diffResult = compareScreenshots(currentPath, baselinePath, threshold);
+		const diffResult = compareScreenshots(currentPath, baselinePath);
 
 		// Copy diff image to diffs dir if it was generated
 		const diffDstPath = join(

--- a/src/commands/wait.ts
+++ b/src/commands/wait.ts
@@ -1,6 +1,7 @@
 import type { Page } from "playwright";
 import type { Response } from "../protocol.ts";
 import { resolveLocator } from "../refs.ts";
+import { DEFAULT_TIMEOUT_MS } from "../timeout.ts";
 
 const POLL_INTERVAL_MS = 100;
 
@@ -8,11 +9,15 @@ const POLL_INTERVAL_MS = 100;
  * Wait for a condition before proceeding. Useful for SPAs where client-side
  * navigation doesn't trigger full page loads.
  *
- * The daemon-level --timeout flag bounds the total wait time.
+ * The poll loops are bounded by `timeoutMs` (the daemon-level --timeout):
+ * the daemon's outer timeout only abandons the promise, it doesn't cancel
+ * it, so without an internal deadline a timed-out wait would keep polling
+ * for the daemon's entire lifetime.
  */
 export async function handleWait(
 	page: Page,
 	args: string[],
+	timeoutMs: number = DEFAULT_TIMEOUT_MS,
 ): Promise<Response> {
 	const subcommand = args[0];
 
@@ -24,16 +29,19 @@ export async function handleWait(
 		};
 	}
 
+	const deadline =
+		Date.now() + (timeoutMs > 0 ? timeoutMs : DEFAULT_TIMEOUT_MS);
+
 	try {
 		switch (subcommand) {
 			case "url":
-				return await waitUrl(page, args.slice(1));
+				return await waitUrl(page, args.slice(1), deadline);
 			case "text":
-				return await waitText(page, args.slice(1));
+				return await waitText(page, args.slice(1), deadline);
 			case "visible":
-				return await waitVisible(page, args.slice(1));
+				return await waitVisible(page, args.slice(1), deadline);
 			case "hidden":
-				return await waitHidden(page, args.slice(1));
+				return await waitHidden(page, args.slice(1), deadline);
 			case "network-idle":
 				return await waitNetworkIdle(page);
 			default: {
@@ -54,7 +62,15 @@ export async function handleWait(
 	}
 }
 
-async function waitUrl(page: Page, args: string[]): Promise<Response> {
+function timedOut(what: string): Response {
+	return { ok: false, error: `Timed out waiting for ${what}` };
+}
+
+async function waitUrl(
+	page: Page,
+	args: string[],
+	deadline: number,
+): Promise<Response> {
 	const substring = args[0];
 	if (!substring) {
 		return {
@@ -64,13 +80,20 @@ async function waitUrl(page: Page, args: string[]): Promise<Response> {
 	}
 
 	while (!page.url().includes(substring)) {
+		if (Date.now() >= deadline) {
+			return timedOut(`URL to contain "${substring}"`);
+		}
 		await sleep(POLL_INTERVAL_MS);
 	}
 
 	return { ok: true, data: `URL contains "${substring}"` };
 }
 
-async function waitText(page: Page, args: string[]): Promise<Response> {
+async function waitText(
+	page: Page,
+	args: string[],
+	deadline: number,
+): Promise<Response> {
 	const text = args[0];
 	if (!text) {
 		return {
@@ -88,11 +111,18 @@ async function waitText(page: Page, args: string[]): Promise<Response> {
 		} catch {
 			// Page may not be ready yet
 		}
+		if (Date.now() >= deadline) {
+			return timedOut(`page text to contain "${text}"`);
+		}
 		await sleep(POLL_INTERVAL_MS);
 	}
 }
 
-async function waitVisible(page: Page, args: string[]): Promise<Response> {
+async function waitVisible(
+	page: Page,
+	args: string[],
+	deadline: number,
+): Promise<Response> {
 	const target = args[0];
 	if (!target) {
 		return {
@@ -115,11 +145,18 @@ async function waitVisible(page: Page, args: string[]): Promise<Response> {
 		} catch {
 			// Element not found yet
 		}
+		if (Date.now() >= deadline) {
+			return timedOut(`element "${target}" to become visible`);
+		}
 		await sleep(POLL_INTERVAL_MS);
 	}
 }
 
-async function waitHidden(page: Page, args: string[]): Promise<Response> {
+async function waitHidden(
+	page: Page,
+	args: string[],
+	deadline: number,
+): Promise<Response> {
 	const target = args[0];
 	if (!target) {
 		return {
@@ -142,6 +179,9 @@ async function waitHidden(page: Page, args: string[]): Promise<Response> {
 		} catch {
 			// Element not found = hidden
 			return { ok: true, data: `Element "${target}" is hidden` };
+		}
+		if (Date.now() >= deadline) {
+			return timedOut(`element "${target}" to become hidden`);
 		}
 		await sleep(POLL_INTERVAL_MS);
 	}

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -85,6 +85,10 @@ const COMMANDS = [
 	"gesture",
 	"devices",
 	"monitor",
+	"perf",
+	"security",
+	"responsive",
+	"extract",
 ];
 
 const GLOBAL_FLAGS = ["--timeout", "--session", "--json", "--config"];
@@ -113,6 +117,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 		"--dry-run",
 		"--stream",
 		"--force",
+		"--webhook",
 	],
 	assert: ["--var", "--json"],
 	healthcheck: [
@@ -122,6 +127,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 		"--junit-property",
 		"--parallel",
 		"--concurrency",
+		"--webhook",
 	],
 	wipe: [],
 	benchmark: ["--iterations", "--json"],
@@ -142,7 +148,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 	plugins: ["--page", "--limit"],
 	session: ["--isolated"],
 	ping: [],
-	status: ["--json", "--watch", "--interval", "--exit-code"],
+	status: ["--json", "--watch", "--interval", "--exit-code", "--metrics"],
 	dialog: [],
 	download: [
 		"--save-to",

--- a/src/config.ts
+++ b/src/config.ts
@@ -239,6 +239,18 @@ const VALID_CONDITION_KEYS = new Set([
 	"textVisible",
 ]);
 
+/**
+ * Keys allowed for an environment's login successCondition. Narrower than
+ * VALID_CONDITION_KEYS: these are the only variants the login flow's
+ * waitForSuccess implements, so accepting the others would let a login
+ * report success without verifying anything.
+ */
+const VALID_SUCCESS_CONDITION_KEYS = new Set([
+	"urlContains",
+	"urlPattern",
+	"elementVisible",
+]);
+
 const VALID_FLOW_STEP_KEYS = new Set([
 	"goto",
 	"click",
@@ -504,7 +516,7 @@ export function validateConfig(data: unknown): string | null {
 		const keys = Object.keys(condition);
 		if (
 			keys.length !== 1 ||
-			!VALID_CONDITION_KEYS.has(keys[0]) ||
+			!VALID_SUCCESS_CONDITION_KEYS.has(keys[0]) ||
 			typeof condition[keys[0]] !== "string"
 		) {
 			return `Invalid browse.config.json: environment '${name}' has an invalid 'successCondition'. Must have exactly one of: urlContains, urlPattern, elementVisible.`;

--- a/src/crawl-engine.ts
+++ b/src/crawl-engine.ts
@@ -4,8 +4,10 @@ import type { Page } from "playwright";
  * Simple glob-to-regex matching for --include/--exclude patterns.
  */
 export function matchGlob(pattern: string, url: string): boolean {
+	// Escape regex metacharacters so only * and ? act as wildcards
+	const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
 	const regex = new RegExp(
-		`^${pattern.replace(/\*/g, ".*").replace(/\?/g, ".")}$`,
+		`^${escaped.replace(/\*/g, ".*").replace(/\?/g, ".")}$`,
 	);
 	return regex.test(url);
 }
@@ -18,7 +20,9 @@ export function normalizeUrl(raw: string): string {
 		const u = new URL(raw);
 		u.hash = "";
 		let href = u.href;
-		if (href.endsWith("/") && u.pathname !== "/") {
+		// Only strip a trailing slash from the path — when a query string is
+		// present the final character belongs to the query, not the path
+		if (href.endsWith("/") && u.pathname !== "/" && !u.search) {
 			href = href.slice(0, -1);
 		}
 		// Lowercase protocol+host (URL constructor already lowercases host)
@@ -364,12 +368,14 @@ export class CrawlEngine {
 			});
 			pagesVisited++;
 
-			// Handle pagination if configured
+			// Handle pagination if configured, bounded by the remaining
+			// page budget so --max-pages holds overall
 			if (this.options.paginate) {
 				const paginationResults = await this.handlePagination(
 					page,
 					entry.url,
 					entry.depth,
+					this.options.maxPages - pagesVisited,
 				);
 				results.push(...paginationResults);
 				pagesVisited += paginationResults.length;
@@ -440,14 +446,15 @@ export class CrawlEngine {
 		page: Page,
 		baseUrl: string,
 		depth: number,
+		remainingBudget: number,
 	): Promise<CrawlResult[]> {
 		const results: CrawlResult[] = [];
 		const selector = this.options.paginate;
-		if (!selector) return results;
+		if (!selector || remainingBudget <= 0) return results;
+		// pageNum labels results (#page-2 onwards; the base page is #1)
 		let pageNum = 1;
-		const maxPaginationPages = this.options.maxPages;
 
-		while (pageNum < maxPaginationPages) {
+		while (results.length < remainingBudget) {
 			try {
 				const element = await page.$(selector);
 				if (!element) break;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 import { chmodSync, rmSync, statSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { homedir } from "node:os";
@@ -157,6 +157,15 @@ import {
 } from "./stealth.ts";
 import { resolveTimeout, withTimeout } from "./timeout.ts";
 
+/** Constant-time token comparison over fixed-length hashes. */
+function tokensMatch(provided: string | undefined, expected: string): boolean {
+	if (!provided) return false;
+	return timingSafeEqual(
+		createHash("sha256").update(provided).digest(),
+		createHash("sha256").update(expected).digest(),
+	);
+}
+
 /**
  * Known flags per command. Commands not listed here skip flag validation
  * (e.g. eval/page-eval/fill/select where all args form freeform data).
@@ -225,7 +234,15 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 	title: [],
 	pdf: [],
 	"element-count": [],
-	trace: ["--screenshots", "--snapshots", "--out", "--port", "--latest"],
+	trace: [
+		"--screenshots",
+		"--snapshots",
+		"--out",
+		"--port",
+		"--latest",
+		"--older-than",
+		"--dry-run",
+	],
 	init: ["--force"],
 	screenshots: ["--older-than", "--dry-run"],
 	report: ["--out", "--title", "--screenshots"],
@@ -249,7 +266,7 @@ const KNOWN_FLAGS: Record<string, string[]> = {
 		"--no-screenshots",
 	],
 	"flow-share": [],
-	video: ["--size", "--out"],
+	video: ["--size", "--out", "--older-than", "--dry-run"],
 	perf: ["--budget", "--json"],
 	security: ["--json"],
 	responsive: ["--breakpoints", "--url", "--out", "--json"],
@@ -471,8 +488,9 @@ export async function startServer(
 	let persistTimer: ReturnType<typeof setTimeout> | undefined;
 	let persistInFlight = false;
 
-	// Per-context trace state so each BrowserContext has isolated tracing
-	const traceStates = new Map<
+	// Per-context trace state so each BrowserContext has isolated tracing.
+	// WeakMap so closed contexts (e.g. isolated sessions) can be collected.
+	const traceStates = new WeakMap<
 		BrowserContext,
 		ReturnType<typeof createTraceState>
 	>();
@@ -496,23 +514,39 @@ export async function startServer(
 		return state;
 	}
 
-	const scratchPages = new Map<BrowserContext, Page>();
+	// Cache the in-flight promise (not the resolved page) so concurrent
+	// callers share one page instead of racing to create and leak extras.
+	const scratchPages = new Map<BrowserContext, Promise<Page>>();
 	async function getScratchPage(targetContext: BrowserContext): Promise<Page> {
-		const existing = scratchPages.get(targetContext);
-		if (
-			existing &&
-			(typeof existing.isClosed !== "function" || !existing.isClosed())
-		) {
-			return existing;
+		const pending = scratchPages.get(targetContext);
+		if (pending) {
+			try {
+				const existing = await pending;
+				if (typeof existing.isClosed !== "function" || !existing.isClosed()) {
+					return existing;
+				}
+			} catch {
+				// Creation failed — fall through and retry below
+			}
 		}
-		const scratchPage = await targetContext.newPage();
-		scratchPage.on("close", () => {
-			if (scratchPages.get(targetContext) === scratchPage) {
+		const creating = (async () => {
+			const scratchPage = await targetContext.newPage();
+			scratchPage.on("close", () => {
+				if (scratchPages.get(targetContext) === creating) {
+					scratchPages.delete(targetContext);
+				}
+			});
+			return scratchPage;
+		})();
+		scratchPages.set(targetContext, creating);
+		try {
+			return await creating;
+		} catch (err) {
+			if (scratchPages.get(targetContext) === creating) {
 				scratchPages.delete(targetContext);
 			}
-		});
-		scratchPages.set(targetContext, scratchPage);
-		return scratchPage;
+			throw err;
+		}
 	}
 
 	// Tab registry for default session
@@ -795,6 +829,12 @@ export async function startServer(
 	}
 
 	idleTimer = createIdleTimer(lifecycleConfig, () => {
+		// A long-running command (watch, subscribe, flow with a large
+		// timeout) must not be killed by the idle timer — defer instead.
+		if (activeCommands > 0) {
+			idleTimer.reset();
+			return;
+		}
 		shutdownOnce();
 	});
 
@@ -902,8 +942,10 @@ export async function startServer(
 				});
 			};
 
-			// Validate auth token if the daemon has one
-			if (token && parsedRequest.token !== token) {
+			// Validate auth token if the daemon has one. Compare hashes with
+			// timingSafeEqual: the token can be the only access control when
+			// the daemon listens on TCP, so avoid a timing oracle.
+			if (token && !tokensMatch(parsedRequest.token, token)) {
 				return reply(
 					serialiseResponse({
 						ok: false,
@@ -940,6 +982,9 @@ export async function startServer(
 						},
 						defaultContext: context,
 						attachListeners: attachPageListeners,
+						onClose: (name) => {
+							videoStates.delete(name);
+						},
 					});
 				}
 
@@ -1191,7 +1236,11 @@ export async function startServer(
 						case "page-eval":
 							return handlePageEval(page, request.args);
 						case "wait":
-							return handleWait(page, request.args);
+							return handleWait(
+								page,
+								request.args,
+								resolveTimeout(request.timeout, config?.timeout),
+							);
 						case "url":
 							return handleUrl(page);
 						case "back":
@@ -1607,6 +1656,10 @@ export async function startServer(
 		let buffer = "";
 		let queue = Promise.resolve();
 		let closing = false;
+
+		// Without a listener, an abrupt client disconnect (ECONNRESET/EPIPE)
+		// would raise an uncaught 'error' event and kill the daemon.
+		socket.on("error", () => {});
 
 		socket.on("data", (chunk) => {
 			buffer += chunk.toString();

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -217,7 +217,12 @@ export function parseRequest(
 				args: parsedEntry.args,
 				timeout: parsedEntry.timeout,
 				session: parsedEntry.session,
-				json: parsedEntry.json,
+				// Preserve absence so the batch-level json flag can apply as
+				// a fallback when the entry doesn't specify one
+				json:
+					(entry as Record<string, unknown>).json === undefined
+						? undefined
+						: parsedEntry.json,
 			};
 		});
 

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -47,6 +47,21 @@ export function buildTarget(target?: RecordedEvent["target"]): string {
 }
 
 /**
+ * Did buildTarget fall back to a CSS selector (rather than an accessible
+ * name)? Selector targets must be emitted as `{ selector }` flow steps —
+ * the replay side treats plain strings as accessible names.
+ */
+function isSelectorTarget(target?: RecordedEvent["target"]): boolean {
+	if (!target) return false;
+	return (
+		!target.accessibleName &&
+		!target.ariaLabel &&
+		!target.placeholder &&
+		Boolean(target.testId || target.selector)
+	);
+}
+
+/**
  * Convert absolute URLs to {{base_url}} variables.
  * Detects the common base from the first navigation URL.
  */
@@ -59,7 +74,14 @@ export function replaceBaseUrl(steps: FlowStep[], baseUrl: string): FlowStep[] {
 	return steps.map((step) => {
 		if ("goto" in step) {
 			const url = (step as { goto: string }).goto;
-			if (url.startsWith(base)) {
+			// Require a path boundary so e.g. https://example.com doesn't
+			// rewrite https://example.communityfoo
+			if (
+				url === base ||
+				url.startsWith(`${base}/`) ||
+				url.startsWith(`${base}?`) ||
+				url.startsWith(`${base}#`)
+			) {
 				return { goto: url.replace(base, "{{base_url}}") };
 			}
 		}
@@ -110,19 +132,31 @@ export function convertToFlowSteps(rawSteps: RawStep[]): FlowStep[] {
 		switch (event.type) {
 			case "click": {
 				const target = buildTarget(event.target);
-				steps.push({ click: target });
+				steps.push(
+					isSelectorTarget(event.target)
+						? { click: { selector: target } }
+						: { click: target },
+				);
 				break;
 			}
 			case "fill": {
 				const target = buildTarget(event.target);
 				const value = event.value ?? "";
-				steps.push({ fill: { [target]: value } });
+				steps.push(
+					isSelectorTarget(event.target)
+						? { fill: { selector: target, value } }
+						: { fill: { [target]: value } },
+				);
 				break;
 			}
 			case "select": {
 				const target = buildTarget(event.target);
 				const value = event.value ?? "";
-				steps.push({ select: { [target]: value } });
+				steps.push(
+					isSelectorTarget(event.target)
+						? { select: { selector: target, value } }
+						: { select: { [target]: value } },
+				);
 				break;
 			}
 			case "navigation": {

--- a/src/safe-pattern.ts
+++ b/src/safe-pattern.ts
@@ -4,17 +4,101 @@
 const MAX_PATTERN_LENGTH = 1024;
 
 /**
+ * Largest bounded repetition count still considered "bounded" by the
+ * nested-quantifier check below.
+ */
+const MAX_BOUNDED_REPEAT = 100;
+
+/** Is there an unbounded (or very large bounded) quantifier at `index`? */
+function unboundedQuantifierAt(pattern: string, index: number): boolean {
+	const ch = pattern[index];
+	if (ch === "*" || ch === "+") return true;
+	if (ch === "{") {
+		const match = pattern.slice(index).match(/^\{(\d+),(\d*)\}/);
+		if (match) {
+			return match[2] === "" || Number(match[2]) > MAX_BOUNDED_REPEAT;
+		}
+	}
+	return false;
+}
+
+/**
+ * Detect nested unbounded quantifiers (e.g. `(a+)*`, `(\d*)+`), the primary
+ * source of catastrophic backtracking. This is a heuristic: it does not catch
+ * every ReDoS pattern (e.g. ambiguous alternation like `(a|a)+`), but it
+ * blocks the common exponential cases.
+ */
+function hasNestedUnboundedQuantifier(pattern: string): boolean {
+	// One entry per open group: did we see an unbounded quantifier inside?
+	const groupStack: { sawUnbounded: boolean }[] = [];
+	let inCharClass = false;
+
+	for (let i = 0; i < pattern.length; i++) {
+		const ch = pattern[i];
+		if (ch === "\\") {
+			i++;
+			continue;
+		}
+		if (inCharClass) {
+			if (ch === "]") inCharClass = false;
+			continue;
+		}
+		switch (ch) {
+			case "[":
+				inCharClass = true;
+				break;
+			case "(":
+				groupStack.push({ sawUnbounded: false });
+				break;
+			case ")": {
+				const group = groupStack.pop();
+				// Unbalanced parens are rejected by the RegExp constructor
+				if (!group) break;
+				const quantified = unboundedQuantifierAt(pattern, i + 1);
+				if (group.sawUnbounded && quantified) return true;
+				if (groupStack.length > 0 && (group.sawUnbounded || quantified)) {
+					groupStack[groupStack.length - 1].sawUnbounded = true;
+				}
+				break;
+			}
+			default:
+				if (
+					groupStack.length > 0 &&
+					unboundedQuantifierAt(pattern, i) &&
+					// `{` only acts as a quantifier when it parses as one;
+					// skip past it either way so its digits aren't re-scanned
+					true
+				) {
+					groupStack[groupStack.length - 1].sawUnbounded = true;
+				}
+				break;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Compile a user-supplied regex string safely.
  *
- * Validates the pattern is well-formed and within length limits to
- * mitigate ReDoS from untrusted flow/config input.
+ * Validates the pattern is well-formed, within length limits, and free of
+ * nested unbounded quantifiers to mitigate ReDoS from untrusted flow/config
+ * input. The nested-quantifier check is a heuristic and does not block every
+ * pathological pattern.
  *
- * @throws {Error} If the pattern is too long or syntactically invalid.
+ * @throws {Error} If the pattern is too long, syntactically invalid, or
+ * contains nested unbounded quantifiers.
  */
 export function compileSafePattern(pattern: string): RegExp {
 	if (pattern.length > MAX_PATTERN_LENGTH) {
 		throw new Error(
 			`Regex pattern exceeds maximum length of ${MAX_PATTERN_LENGTH} characters.`,
+		);
+	}
+
+	if (hasNestedUnboundedQuantifier(pattern)) {
+		throw new Error(
+			`Regex pattern "${pattern}" contains nested unbounded quantifiers, which can cause catastrophic backtracking.`,
 		);
 	}
 

--- a/src/stealth.ts
+++ b/src/stealth.ts
@@ -77,7 +77,7 @@ export function getHighEntropyDefaults(): {
  * Returns the full version string (e.g. "146.0.7680.81").
  */
 async function detectChromeVersion(channel: string): Promise<string | null> {
-	const { execSync } = await import("node:child_process");
+	const { execFileSync } = await import("node:child_process");
 	const chromePaths: Record<string, string[]> = {
 		chrome: [
 			"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
@@ -88,9 +88,12 @@ async function detectChromeVersion(channel: string): Promise<string | null> {
 	const candidates = chromePaths[channel] ?? [channel];
 	for (const bin of candidates) {
 		try {
-			const output = execSync(`"${bin}" --version 2>/dev/null`, {
+			// execFileSync avoids interpolating the (config-supplied) binary
+			// name into a shell command
+			const output = execFileSync(bin, ["--version"], {
 				encoding: "utf-8",
 				timeout: 5000,
+				stdio: ["ignore", "pipe", "ignore"],
 			}).trim();
 			const match = output.match(/(\d+\.\d+\.\d+\.\d+)/);
 			if (match) return match[1];
@@ -348,7 +351,7 @@ export async function applyStealthScripts(
 					runtime.getVersion = makeNativeFunction(
 						"getVersion",
 						function getVersion() {
-							return chromeVersion || "0";
+							return chromeFullVersion || "0";
 						},
 					);
 				if (!("reload" in runtime))
@@ -562,9 +565,13 @@ export async function applyStealthScripts(
 				// the browser returns red as the default background
 				return new Proxy(style, {
 					get(target, prop) {
-						const value = (target as Record<string | symbol, string>)[
-							prop as string
-						];
+						const value = Reflect.get(target, prop);
+						// Bind methods (getPropertyValue, item, ...) to the real
+						// CSSStyleDeclaration — calling them with the Proxy as
+						// receiver fails native brand checks ("Illegal invocation")
+						if (typeof value === "function") {
+							return value.bind(target);
+						}
 						// If the computed background color is red (headless signature), return black
 						if (prop === "backgroundColor" && value === "rgb(255, 0, 0)") {
 							return "rgb(0, 0, 0)"; // Return black instead of red

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -10,14 +10,19 @@ export async function withTimeout<T>(
 ): Promise<T> {
 	const effectiveMs = ms > 0 ? ms : DEFAULT_TIMEOUT_MS;
 
-	const timeout = new Promise<never>((_, reject) =>
-		setTimeout(
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(
 			() => reject(new Error(`Command timed out after ${effectiveMs}ms`)),
 			effectiveMs,
-		),
-	);
+		);
+	});
 
-	return Promise.race([fn(), timeout]);
+	try {
+		return await Promise.race([fn(), timeout]);
+	} finally {
+		clearTimeout(timer);
+	}
 }
 
 /**

--- a/src/tracker-database.ts
+++ b/src/tracker-database.ts
@@ -59,6 +59,21 @@ export const TRACKER_DOMAINS: Record<
 	"t.co": { name: "Twitter", category: "social" },
 };
 
+/**
+ * Tracker cookies that carry a dynamic suffix (e.g. `_ga_XXXXXX`). Only these
+ * are matched by prefix — a blanket prefix match over all tracker names would
+ * misclassify first-party cookies (e.g. `front_session` matching `fr`).
+ */
+const TRACKER_COOKIE_PREFIXES: Record<
+	string,
+	{ name: string; category: TrackerCategory }
+> = {
+	_ga_: { name: "Google Analytics", category: "analytics" },
+	_gat_: { name: "Google Analytics", category: "analytics" },
+	_hj: { name: "Hotjar", category: "analytics" },
+	_gcl_: { name: "Google Ads Conversion", category: "advertising" },
+};
+
 export function classifyCookie(
 	name: string,
 ): { tracker: string; category: TrackerCategory } | null {
@@ -70,8 +85,8 @@ export function classifyCookie(
 		};
 	}
 
-	// Prefix match (e.g., _ga_XXXXX)
-	for (const [prefix, info] of Object.entries(TRACKER_COOKIES)) {
+	// Prefix match for dynamic-suffix cookies (e.g., _ga_XXXXX)
+	for (const [prefix, info] of Object.entries(TRACKER_COOKIE_PREFIXES)) {
 		if (name.startsWith(prefix)) {
 			return { tracker: info.name, category: info.category };
 		}

--- a/test/crawl.test.ts
+++ b/test/crawl.test.ts
@@ -38,6 +38,12 @@ describe("normalizeUrl", () => {
 			"https://example.com/page",
 		);
 	});
+
+	test("keeps a trailing slash that belongs to the query string", () => {
+		expect(normalizeUrl("https://example.com/search?q=foo/")).toBe(
+			"https://example.com/search?q=foo/",
+		);
+	});
 });
 
 describe("matchGlob", () => {
@@ -61,6 +67,16 @@ describe("matchGlob", () => {
 
 	test("matches URL path patterns", () => {
 		expect(matchGlob("*/blog/*", "https://example.com/blog/post-1")).toBe(true);
+	});
+
+	test("treats regex metacharacters as literals", () => {
+		expect(matchGlob("*example.com*", "https://xexamplexcom.evil")).toBe(false);
+		expect(matchGlob("*price (usd)*", "https://shop.com/price (usd)")).toBe(
+			true,
+		);
+		// Patterns with regex specials must not throw
+		expect(matchGlob("*[id]*", "https://example.com/[id]/edit")).toBe(true);
+		expect(matchGlob("*a+b*", "https://example.com/a+b")).toBe(true);
 	});
 });
 

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -109,14 +109,14 @@ describe("parseRequest", () => {
 					args: [],
 					timeout: undefined,
 					session: undefined,
-					json: false,
+					json: undefined,
 				},
 				{
 					cmd: "url",
 					args: [],
 					timeout: undefined,
 					session: undefined,
-					json: false,
+					json: undefined,
 				},
 			],
 			continueOnError: true,
@@ -125,6 +125,16 @@ describe("parseRequest", () => {
 			json: false,
 			token: undefined,
 		});
+	});
+
+	test("batch entries keep an explicit json flag and inherit the batch-level flag otherwise", () => {
+		const result = parseRequest(
+			'{"batch":[{"cmd":"ping","args":[],"json":true},{"cmd":"url","args":[]}],"json":true}',
+		);
+		if (!("batch" in result)) throw new Error("expected batch request");
+		expect(result.batch[0]?.json).toBe(true);
+		expect(result.batch[1]?.json).toBeUndefined();
+		expect(result.json).toBe(true);
 	});
 
 	test("throws on malformed JSON", () => {

--- a/test/safe-pattern.test.ts
+++ b/test/safe-pattern.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { compileSafePattern } from "../src/safe-pattern.ts";
+
+describe("compileSafePattern", () => {
+	test("compiles ordinary patterns", () => {
+		expect(compileSafePattern("foo.*bar").test("fooXbar")).toBe(true);
+		expect(compileSafePattern("^/dashboard").test("/dashboard")).toBe(true);
+		expect(compileSafePattern("\\d{2,4}").test("123")).toBe(true);
+	});
+
+	test("allows sibling (non-nested) quantifiers", () => {
+		expect(() => compileSafePattern("a*b+c?")).not.toThrow();
+		expect(() => compileSafePattern("(a*)(b+)")).not.toThrow();
+		expect(() => compileSafePattern("(abc)+def")).not.toThrow();
+	});
+
+	test("allows quantifiers inside character classes", () => {
+		expect(() => compileSafePattern("([*+])+")).not.toThrow();
+	});
+
+	test("rejects overly long patterns", () => {
+		expect(() => compileSafePattern("a".repeat(2000))).toThrow(
+			/maximum length/,
+		);
+	});
+
+	test("rejects invalid patterns", () => {
+		expect(() => compileSafePattern("(unclosed")).toThrow(/Invalid regex/);
+	});
+
+	test("rejects nested unbounded quantifiers", () => {
+		expect(() => compileSafePattern("(a+)*")).toThrow(/nested/);
+		expect(() => compileSafePattern("(a*)+")).toThrow(/nested/);
+		expect(() => compileSafePattern("(\\d+)+$")).toThrow(/nested/);
+		expect(() => compileSafePattern("((ab)+)*")).toThrow(/nested/);
+		expect(() => compileSafePattern("(a{1,})*")).toThrow(/nested/);
+		expect(() => compileSafePattern("(x(a+))+")).toThrow(/nested/);
+	});
+});

--- a/test/tracker-database.test.ts
+++ b/test/tracker-database.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { classifyCookie, classifyDomain } from "../src/tracker-database.ts";
+
+describe("classifyCookie", () => {
+	test("matches known tracker cookies exactly", () => {
+		expect(classifyCookie("_ga")?.tracker).toBe("Google Analytics");
+		expect(classifyCookie("fr")?.tracker).toBe("Facebook");
+		expect(classifyCookie("IDE")?.tracker).toBe("Google DoubleClick");
+	});
+
+	test("matches dynamic-suffix cookies by prefix", () => {
+		expect(classifyCookie("_ga_ABC123")?.tracker).toBe("Google Analytics");
+		expect(classifyCookie("_hjSessionUser_1")?.tracker).toBe("Hotjar");
+		expect(classifyCookie("_gcl_dc")?.tracker).toBe("Google Ads Conversion");
+	});
+
+	test("does not misclassify first-party cookies sharing a short prefix", () => {
+		expect(classifyCookie("front_session")).toBeNull();
+		expect(classifyCookie("fresh_token")).toBeNull();
+		expect(classifyCookie("IDENTITY")).toBeNull();
+		expect(classifyCookie("DSID_custom")).toBeNull();
+	});
+});
+
+describe("classifyDomain", () => {
+	test("matches tracker domains and subdomains", () => {
+		expect(
+			classifyDomain("https://www.google-analytics.com/collect")?.tracker,
+		).toBe("Google Analytics");
+		expect(classifyDomain("https://sub.doubleclick.net/x")?.tracker).toBe(
+			"Google DoubleClick",
+		);
+	});
+
+	test("does not match lookalike domains", () => {
+		expect(classifyDomain("https://notdoubleclick.net/x")).toBeNull();
+	});
+
+	test("returns null for invalid URLs", () => {
+		expect(classifyDomain("not-a-url")).toBeNull();
+	});
+});


### PR DESCRIPTION
# Full-repo review fixes

A systematic review of the codebase (core daemon, config/plugins, flow machinery, all 79 command handlers, scripts/packaging, docs) surfaced ~35 high-confidence defects. This PR fixes all of them except one architectural item noted at the bottom.

## Crashes and broken commands

- **`browse diff` crashed on every invocation**: the handler declared `_deps` but the body referenced `deps` (`ReferenceError` at runtime; tsc isn't in CI so nothing caught it).
- **Stealth mode broke real pages** (two bugs): `chrome.runtime.getVersion()` referenced an undefined `chromeVersion` identifier, and the `getComputedStyle` proxy returned unbound native methods so `style.getPropertyValue(...)` threw `Illegal invocation` on every stealth page — itself a bot-detection signal.
- **`extract table @ref`** used the 0-based `nthMatch` with 1-based `:nth-of-type`, selecting the wrong table (or none). Now indexes `querySelectorAll` results directly.
- **Crawl globs**: `--include`/`--exclude` patterns containing `(`, `[`, `+` threw mid-crawl, and `.` acted as a wildcard (`*.example.com*` matched `xexamplexcom.evil`). Metacharacters are now escaped.

## Daemon robustness

- Accepted sockets had **no `error` listener** — an abrupt client disconnect (ECONNRESET) raised an uncaught exception and killed the daemon, orphaning the browser.
- The **idle timer could shut the daemon down mid-command**; it now defers while commands are active.
- **`browse batch file.json --json` was ignored**: the batch-level `json` flag never propagated because entries always parsed to a concrete `false`.
- **`wait url/text/visible/hidden` poll loops never terminated** — the outer timeout only abandons the promise. Timed-out waits polled the page every 100&nbsp;ms for the daemon's entire lifetime. Loops are now bounded by the request timeout.
- **`record start/stop` leaked a `framenavigated` listener per cycle**, duplicating `goto` steps in saved flows.
- Smaller leaks/races: `withTimeout` timers now cleared on settle; scratch-page creation caches the in-flight promise; trace state moved to a `WeakMap`; per-session video state released on session close; auth token compared with `timingSafeEqual` (relevant for `--listen tcp://`).

## Wrong results

- **`browse compliance` on the current page always passed the cookie audit** — it audited a freshly created (empty) context. With a URL, the tracker check read the main session's network buffer instead of the audited page's requests. Both fixed.
- **Tracker cookie classification**: blanket prefix matching flagged first-party cookies like `front_session` as Facebook (`fr`) and `IDENTITY` as DoubleClick (`IDE`). Prefix matching is now limited to dynamic-suffix prefixes (`_ga_`, `_hj`, …).
- **Login could report success without verifying anything**: config validation accepted `textVisible`/`elementNotVisible` success conditions that `waitForSuccess` doesn't implement (it fell through and resolved immediately). Validation now only accepts the three implemented variants.
- **Recorded flows that fell back to CSS selectors could never replay** — replay treated the selector string as an accessible name. The recorder now emits the `{ selector }` step form the flow schema already supports.
- `a11y headings` collected headings grouped by level, masking real skip detection; `gesture` ignored `.nth()` disambiguation for duplicate-name refs; crawl pagination could exceed `--max-pages` by ~2x; URL normalization stripped slashes out of query strings; `vrt` passed its pass/fail percentage as a per-pixel colour tolerance; `cookies --domain badexample.com` matched `.example.com`; `throttle --upload/--latency` without `--download` was rejected; `subscribe` silently accepted (and defaulted to!) `network`/`download` events it never listened for; `page-eval` re-executed side-effectful code on runtime errors; `do` ignored HTTP error statuses and double-appended `/v1` to `OPENAI_BASE_URL`; `trace clean`/`video clean` documented flags were rejected by daemon flag validation; shell completions were missing four commands and several flags.

## Security hardening

- **`compileSafePattern` claimed ReDoS mitigation but only capped length** — `(a+)*` is 6 chars and hangs the daemon's event loop (flows are an untrusted input via `flow-share install`). It now rejects nested unbounded quantifiers (documented as a heuristic).
- **`stealth.ts` interpolated the config-supplied browser channel into a shell command** (`execSync`); now `execFileSync` with an argument vector.

## Packaging / docs

- **Dockerfile**: the runtime image (`playwright:v1.54.1`) had neither Chrome nor the chromium revision the embedded patchright 1.58.2 expects — the published image could only run `--help`. It now installs a matching Chrome.
- **install.sh** installed browsers via upstream `playwright`, whose browser revisions the patchright-based release binary can't find; switched to `patchright` (matching setup.sh/CI).
- **docs/plugins.md** told plugin authors to `import from "browse/plugin"`, which doesn't exist (package is private/unpublished); now points at the relative-path pattern the bundled examples use.

## Tests

- New: `test/safe-pattern.test.ts`, `test/tracker-database.test.ts`, plus regression tests for glob escaping, query-string normalization, and batch `json` fallback.
- `bun test`: **1358 pass, 0 fail** (was 1343); `biome check` clean; binary compiles and runs.

## Known limitation (intentionally not fixed here)

The **ref registry (`src/refs.ts`) is module-global** while sessions/tabs execute concurrently: one session's snapshot/navigation can invalidate or remap another session's `@e` refs. Fixing it properly means moving the registry into `TabState` and threading it through ~36 call sites and ~200 test call sites — a refactor that deserves its own PR rather than riding along here. Current behavior is conservatively safe for single-session use (any navigation marks refs stale).

https://claude.ai/code/session_018W3Am9a8RWjW8drwJCBNHd

---
_Generated by [Claude Code](https://claude.ai/code/session_018W3Am9a8RWjW8drwJCBNHd)_